### PR TITLE
use underscore for overline to reduce the gap

### DIFF
--- a/lua/nabla/ascii.lua
+++ b/lua/nabla/ascii.lua
@@ -21,7 +21,9 @@ local put_if_only_sup
 
 
 local style = {
-	div_bar = "―",
+	div_high_bar = "‾",
+	div_middle_bar = "―",
+	div_low_bar = "_",
 
 	left_top_par    = '⎛',
 	left_middle_par = '⎜',
@@ -1562,7 +1564,7 @@ function to_ascii(explist, exp_i)
     		local bar = ""
     		local w = math.max(leftgrid.w, rightgrid.w)
     		for x=1,w do
-    			bar = bar .. style.div_bar
+    			bar = bar .. style.div_middle_bar
     		end
 
 
@@ -1761,7 +1763,7 @@ function to_ascii(explist, exp_i)
     	  local bar = ""
     	  local w = belowgrid.w
     	  for x=1,w do
-    	  	bar = bar .. style.div_bar
+    	  	bar = bar .. style.div_low_bar
     	  end
     	  local overline = grid:new(w, 1, { bar })
     	  g = overline:join_vert(belowgrid)
@@ -1773,7 +1775,7 @@ function to_ascii(explist, exp_i)
     	  local txt = ""
     	  local w = belowgrid.w
     	  for x=1,w-1 do
-    	  	txt = txt .. style.div_bar
+    	  	txt = txt .. style.div_middle_bar
     	  end
     	  txt = txt .. style.vec_arrow
 

--- a/src/core/ascii.lua.t
+++ b/src/core/ascii.lua.t
@@ -203,13 +203,15 @@ for y=1,h do
 end
 
 @style_variables+=
-div_bar = "―",
+div_high_bar = "‾",
+div_middle_bar = "―",
+div_low_bar = "_",
 
 @generate_appropriate_size_fraction_bar+=
 local bar = ""
 local w = math.max(leftgrid.w, rightgrid.w)
 for x=1,w do
-	bar = bar .. style.div_bar
+	bar = bar .. style.div_middle_bar
 end
 
 @grid_data+=

--- a/src/core/overline.lua.t
+++ b/src/core/overline.lua.t
@@ -12,6 +12,6 @@ elseif name == "overline" then
 local bar = ""
 local w = belowgrid.w
 for x=1,w do
-	bar = bar .. style.div_bar
+	bar = bar .. style.div_low_bar
 end
 local overline = grid:new(w, 1, { bar })

--- a/src/core/vec.lua.t
+++ b/src/core/vec.lua.t
@@ -14,7 +14,7 @@ vec_arrow = "→",
 local txt = ""
 local w = belowgrid.w
 for x=1,w-1 do
-	txt = txt .. style.div_bar
+	txt = txt .. style.div_middle_bar
 end
 txt = txt .. style.vec_arrow
 


### PR DESCRIPTION
Currently \overline looks like this:
![2023-04-07_18h52m12s_screenshot](https://user-images.githubusercontent.com/63882624/230656907-71c8227e-423d-445a-a31f-6890796e1e12.png)
This pull request makes it look like this:
![2023-04-07_18h51m47s_screenshot](https://user-images.githubusercontent.com/63882624/230656913-1de04098-dbf2-4609-8f0e-a5be62261b6e.png)


I added the `div_high_bar` variable because I thought it could be useful for underlining. I might make a pull request for this at some point.

Also, I wasn't sure at all about how to generate the lua files from the source code so I assume that needs to be done before this can be merged. I tried installing ntangle.nvim and it seemed to modify a lua file but I wasn't sure that the output was correct. Anyway this should be slightly easier to review at least.