### PR TITLE
Add Support for Dot Derivative Notation

### DIFF
--- a/lua/nabla/ascii.lua
+++ b/lua/nabla/ascii.lua
@@ -1740,6 +1740,12 @@ function to_ascii(explist, exp_i)
     		g = c2
 
 
+    	elseif name == "dot" then
+    	  local belowgrid = to_ascii({explist[exp_i+1]}, 1)
+    	  exp_i = exp_i + 1
+    	  local dot = grid:new(1, 1, { "." })
+    	  g = dot:join_vert(belowgrid)
+    	  g.my = belowgrid.my + 1
     	elseif name == "hat" then
     	  local belowgrid = to_ascii({explist[exp_i+1]}, 1)
     	  exp_i = exp_i + 1

--- a/lua/nabla/ascii.lua
+++ b/lua/nabla/ascii.lua
@@ -1740,6 +1740,18 @@ function to_ascii(explist, exp_i)
     		g = c2
 
 
+    	elseif name == "dddot" then
+    	  local belowgrid = to_ascii({explist[exp_i+1]}, 1)
+    	  exp_i = exp_i + 1
+    	  local dot = grid:new(1, 1, { "…" })
+    	  g = dot:join_vert(belowgrid)
+    	  g.my = belowgrid.my + 1
+    	elseif name == "ddot" then
+    	  local belowgrid = to_ascii({explist[exp_i+1]}, 1)
+    	  exp_i = exp_i + 1
+    	  local dot = grid:new(1, 1, { "‥" })
+    	  g = dot:join_vert(belowgrid)
+    	  g.my = belowgrid.my + 1
     	elseif name == "dot" then
     	  local belowgrid = to_ascii({explist[exp_i+1]}, 1)
     	  exp_i = exp_i + 1

--- a/src/core/dddot.lua.t
+++ b/src/core/dddot.lua.t
@@ -1,0 +1,8 @@
+##../ascii
+@transform_function_into_ascii+=
+elseif name == "dddot" then
+  local belowgrid = to_ascii({explist[exp_i+1]}, 1)
+  exp_i = exp_i + 1
+  local dot = grid:new(1, 1, { "…" })
+  g = dot:join_vert(belowgrid)
+  g.my = belowgrid.my + 1

--- a/src/core/ddot.lua.t
+++ b/src/core/ddot.lua.t
@@ -1,0 +1,8 @@
+##../ascii
+@transform_function_into_ascii+=
+elseif name == "ddot" then
+  local belowgrid = to_ascii({explist[exp_i+1]}, 1)
+  exp_i = exp_i + 1
+  local dot = grid:new(1, 1, { "‥" })
+  g = dot:join_vert(belowgrid)
+  g.my = belowgrid.my + 1

--- a/src/core/dot.lua.t
+++ b/src/core/dot.lua.t
@@ -1,0 +1,8 @@
+##../ascii
+@transform_function_into_ascii+=
+elseif name == "dot" then
+  local belowgrid = to_ascii({explist[exp_i+1]}, 1)
+  exp_i = exp_i + 1
+  local dot = grid:new(1, 1, { "." })
+  g = dot:join_vert(belowgrid)
+  g.my = belowgrid.my + 1


### PR DESCRIPTION
Dot derivative notation is common in the field of Physics to denote derivatives of a variable with respect to time.

The symbols can be accessed with the LaTeX commands \dot{}, \ddot{}, and \dddot{}.

![screenshot](https://github.com/jbyuki/nabla.nvim/assets/95952574/c7fd87ee-4c4d-4d3f-8544-12d6a10a7b89)