### PR TITLE
Added a .stylua.toml file to configure stylua

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,3 @@
+collapse_simple_statement = "Always"
+indent_type = "Spaces"
+indent_width = 4

--- a/lua/nabla.lua
+++ b/lua/nabla.lua
@@ -5,7 +5,7 @@ local parser = require("nabla.latex")
 local ascii = require("nabla.ascii")
 
 local ts_utils = vim.treesitter
-local utils=require"nabla.utils"
+local utils = require("nabla.utils")
 
 local autogen_autocmd = {}
 local autogen_flag = false
@@ -18,7 +18,6 @@ local saved_concealcursor = {}
 local mult_virt_ns = {}
 
 local saved_wrapsettings = {}
-
 
 local colorize
 
@@ -33,608 +32,639 @@ local toggle_virt
 local is_virt_enabled
 
 function colorize(g, first_dx, dx, dy, ns_id, drawing, px, py, buf)
-  if g.t == "num" then
-    local off
-    if dy == 0 then off = first_dx else off = dx end
-
-    local sx = vim.str_byteindex(drawing[dy+1], off)
-    local se = vim.str_byteindex(drawing[dy+1], off+g.w)
-
-    local of
-    if dy == 0 then of = px else of = 0 end
-    vim.api.nvim_buf_add_highlight(buf, ns_id, "@number", py+dy, of+sx,of+se)
-  end
-
-  if g.t == "sym" then
-    local off
-    if dy == 0 then off = first_dx else off = dx end
-
-    local sx = vim.str_byteindex(drawing[dy+1], off)
-    local se = vim.str_byteindex(drawing[dy+1], off+g.w)
-
-    if string.match(g.content[1], "^%a") then
-      local of
-      if dy == 0 then of = px else of = 0 end
-      vim.api.nvim_buf_add_highlight(buf, ns_id, "@string", dy+py, of+sx, of+se)
-
-    elseif string.match(g.content[1], "^%d") then
-      local of
-      if dy == 0 then of = px else of = 0 end
-      vim.api.nvim_buf_add_highlight(buf, ns_id, "@number", dy+py, of+sx, of+se)
-
-    else
-      for y=1,g.h do
+    if g.t == "num" then
         local off
-        if y+dy == 1 then off = first_dx else off = dx end
+        if dy == 0 then
+            off = first_dx
+        else
+            off = dx
+        end
 
-        local sx = vim.str_byteindex(drawing[dy+y], off)
-        local se = vim.str_byteindex(drawing[dy+y], off+g.w)
+        local sx = vim.str_byteindex(drawing[dy + 1], off)
+        local se = vim.str_byteindex(drawing[dy + 1], off + g.w)
+
         local of
-        if y+dy == 1 then of = px else of = 0 end
-        vim.api.nvim_buf_add_highlight(buf, ns_id, "@operator", dy+py+y-1, of+sx, of+se)
-      end
+        if dy == 0 then
+            of = px
+        else
+            of = 0
+        end
+        vim.api.nvim_buf_add_highlight(buf, ns_id, "@number", py + dy, of + sx, of + se)
     end
-  end
 
-  if g.t == "op" then
-    for y=1,g.h do
-      local off
-      if y+dy == 1 then off = first_dx else off = dx end
+    if g.t == "sym" then
+        local off
+        if dy == 0 then
+            off = first_dx
+        else
+            off = dx
+        end
 
-      local sx = vim.str_byteindex(drawing[dy+y], off)
-      local se = vim.str_byteindex(drawing[dy+y], off+g.w)
+        local sx = vim.str_byteindex(drawing[dy + 1], off)
+        local se = vim.str_byteindex(drawing[dy + 1], off + g.w)
 
-      local of
-      if dy+y == 1 then of = px else of = 0 end
-      vim.api.nvim_buf_add_highlight(buf, ns_id, "@operator", dy+py+y-1, of+sx, of+se)
+        if string.match(g.content[1], "^%a") then
+            local of
+            if dy == 0 then
+                of = px
+            else
+                of = 0
+            end
+            vim.api.nvim_buf_add_highlight(buf, ns_id, "@string", dy + py, of + sx, of + se)
+        elseif string.match(g.content[1], "^%d") then
+            local of
+            if dy == 0 then
+                of = px
+            else
+                of = 0
+            end
+            vim.api.nvim_buf_add_highlight(buf, ns_id, "@number", dy + py, of + sx, of + se)
+        else
+            for y = 1, g.h do
+                local off
+                if y + dy == 1 then
+                    off = first_dx
+                else
+                    off = dx
+                end
+
+                local sx = vim.str_byteindex(drawing[dy + y], off)
+                local se = vim.str_byteindex(drawing[dy + y], off + g.w)
+                local of
+                if y + dy == 1 then
+                    of = px
+                else
+                    of = 0
+                end
+                vim.api.nvim_buf_add_highlight(buf, ns_id, "@operator", dy + py + y - 1, of + sx, of + se)
+            end
+        end
     end
-  end
-  if g.t == "par" then
-    for y=1,g.h do
-      local off
-      if y+dy == 1 then off = first_dx else off = dx end
 
-      local sx = vim.str_byteindex(drawing[dy+y], off)
-      local se = vim.str_byteindex(drawing[dy+y], off+g.w)
+    if g.t == "op" then
+        for y = 1, g.h do
+            local off
+            if y + dy == 1 then
+                off = first_dx
+            else
+                off = dx
+            end
 
-      local of
-      if y+dy == 1 then of = px else of = 0 end
-      vim.api.nvim_buf_add_highlight(buf, ns_id, "@operator", dy+py+y-1, of+sx, of+se)
+            local sx = vim.str_byteindex(drawing[dy + y], off)
+            local se = vim.str_byteindex(drawing[dy + y], off + g.w)
+
+            local of
+            if dy + y == 1 then
+                of = px
+            else
+                of = 0
+            end
+            vim.api.nvim_buf_add_highlight(buf, ns_id, "@operator", dy + py + y - 1, of + sx, of + se)
+        end
     end
-  end
+    if g.t == "par" then
+        for y = 1, g.h do
+            local off
+            if y + dy == 1 then
+                off = first_dx
+            else
+                off = dx
+            end
 
-  if g.t == "var" then
-    local off
-    if dy == 0 then off = first_dx else off = dx end
+            local sx = vim.str_byteindex(drawing[dy + y], off)
+            local se = vim.str_byteindex(drawing[dy + y], off + g.w)
 
-    local sx = vim.str_byteindex(drawing[dy+1], off)
-    local se = vim.str_byteindex(drawing[dy+1], off+g.w)
+            local of
+            if y + dy == 1 then
+                of = px
+            else
+                of = 0
+            end
+            vim.api.nvim_buf_add_highlight(buf, ns_id, "@operator", dy + py + y - 1, of + sx, of + se)
+        end
+    end
 
-    local of
-    if dy == 0 then of = px else of = 0 end
-    vim.api.nvim_buf_add_highlight(buf, ns_id, "@string", dy+py, of+sx, of+se)
-  end
+    if g.t == "var" then
+        local off
+        if dy == 0 then
+            off = first_dx
+        else
+            off = dx
+        end
 
-  for _, child in ipairs(g.children) do
-    colorize(child[1], child[2]+first_dx, child[2]+dx, child[3]+dy, ns_id, drawing, px, py, buf)
-  end
+        local sx = vim.str_byteindex(drawing[dy + 1], off)
+        local se = vim.str_byteindex(drawing[dy + 1], off + g.w)
 
+        local of
+        if dy == 0 then
+            of = px
+        else
+            of = 0
+        end
+        vim.api.nvim_buf_add_highlight(buf, ns_id, "@string", dy + py, of + sx, of + se)
+    end
+
+    for _, child in ipairs(g.children) do
+        colorize(child[1], child[2] + first_dx, child[2] + dx, child[3] + dy, ns_id, drawing, px, py, buf)
+    end
 end
 
 function colorize_virt(g, virt_lines, first_dx, dx, dy)
-  if g.t == "num" then
-    local off
-    if dy == 0 then off = first_dx else off = dx end
-
-    for i=1,g.w do
-      virt_lines[dy+1][off+i][2] = "@number"
-    end
-  end
-
-  if g.t == "sym" then
-    local off
-    if dy == 0 then off = first_dx else off = dx end
-
-    if string.match(g.content[1], "^%a") then
-      for i=1,g.w do
-        virt_lines[dy+1][off+i][2] = "@string"
-      end
-
-    elseif string.match(g.content[1], "^%d") then
-      for i=1,g.w do
-        virt_lines[dy+1][off+i][2] = "@number"
-      end
-
-
-    else
-      for y=1,g.h do
+    if g.t == "num" then
         local off
-        if y+dy == 1 then off = first_dx else off = dx end
-
-        for i=1,g.w do
-          virt_lines[dy+y][off+i][2] = "@operator"
+        if dy == 0 then
+            off = first_dx
+        else
+            off = dx
         end
 
-      end
+        for i = 1, g.w do
+            virt_lines[dy + 1][off + i][2] = "@number"
+        end
     end
-  end
 
-  if g.t == "op" then
-    for y=1,g.h do
-      local off
-      if y+dy == 1 then off = first_dx else off = dx end
+    if g.t == "sym" then
+        local off
+        if dy == 0 then
+            off = first_dx
+        else
+            off = dx
+        end
 
-      for i=1,g.w do
-        virt_lines[dy+y][off+i][2] = "@operator"
-      end
+        if string.match(g.content[1], "^%a") then
+            for i = 1, g.w do
+                virt_lines[dy + 1][off + i][2] = "@string"
+            end
+        elseif string.match(g.content[1], "^%d") then
+            for i = 1, g.w do
+                virt_lines[dy + 1][off + i][2] = "@number"
+            end
+        else
+            for y = 1, g.h do
+                local off
+                if y + dy == 1 then
+                    off = first_dx
+                else
+                    off = dx
+                end
+
+                for i = 1, g.w do
+                    virt_lines[dy + y][off + i][2] = "@operator"
+                end
+            end
+        end
     end
-  end
-  if g.t == "par" then
-    for y=1,g.h do
-      local off
-      if y+dy == 1 then off = first_dx else off = dx end
 
-      for i=1,g.w do
-        virt_lines[dy+y][off+i][2] = "@operator"
-      end
+    if g.t == "op" then
+        for y = 1, g.h do
+            local off
+            if y + dy == 1 then
+                off = first_dx
+            else
+                off = dx
+            end
+
+            for i = 1, g.w do
+                virt_lines[dy + y][off + i][2] = "@operator"
+            end
+        end
     end
-  end
+    if g.t == "par" then
+        for y = 1, g.h do
+            local off
+            if y + dy == 1 then
+                off = first_dx
+            else
+                off = dx
+            end
 
-  if g.t == "var" then
-    local off
-    if dy == 0 then off = first_dx else off = dx end
-
-    for i=1,g.w do
-      virt_lines[dy+1][off+i][2] = "@string"
+            for i = 1, g.w do
+                virt_lines[dy + y][off + i][2] = "@operator"
+            end
+        end
     end
-  end
 
-  for _, child in ipairs(g.children) do
-    colorize_virt(child[1], virt_lines, child[2]+first_dx, child[2]+dx, child[3]+dy)
-  end
+    if g.t == "var" then
+        local off
+        if dy == 0 then
+            off = first_dx
+        else
+            off = dx
+        end
 
+        for i = 1, g.w do
+            virt_lines[dy + 1][off + i][2] = "@string"
+        end
+    end
+
+    for _, child in ipairs(g.children) do
+        colorize_virt(child[1], virt_lines, child[2] + first_dx, child[2] + dx, child[3] + dy)
+    end
 end
 
 local function gen_drawing(lines)
-  local parser = require("nabla.latex")
-  local ascii = require("nabla.ascii")
-  local line = table.concat(lines, " ")
+    local parser = require("nabla.latex")
+    local ascii = require("nabla.ascii")
+    local line = table.concat(lines, " ")
 
-  local success, exp = pcall(parser.parse_all, line)
+    local success, exp = pcall(parser.parse_all, line)
 
+    if success and exp then
+        local succ, g = pcall(ascii.to_ascii, { exp }, 1)
+        if not succ then
+            print(g)
+            return 0
+        end
 
-  if success and exp then
-    local succ, g = pcall(ascii.to_ascii, {exp}, 1)
-    if not succ then
-      print(g)
-      return 0
+        if not g or g == "" then
+            vim.api.nvim_echo({ { "Empty expression detected. Please use the $...$ syntax.", "ErrorMsg" } }, false, {})
+            return 0
+        end
+
+        local drawing = {}
+        for row in vim.gsplit(tostring(g), "\n") do
+            table.insert(drawing, row)
+        end
+        if whitespace then
+            for i = 1, #drawing do
+                drawing[i] = whitespace .. drawing[i]
+            end
+        end
+
+        return drawing
     end
-
-    if not g or g == "" then
-      vim.api.nvim_echo({{"Empty expression detected. Please use the $...$ syntax.", "ErrorMsg"}}, false, {})
-      return 0
-    end
-
-    local drawing = {}
-    for row in vim.gsplit(tostring(g), "\n") do
-    	table.insert(drawing, row)
-    end
-    if whitespace then
-    	for i=1,#drawing do
-    		drawing[i] = whitespace .. drawing[i]
-    	end
-    end
-
-
-
-    return drawing
-  end
-  return 0
+    return 0
 end
 
 local function popup(overrides)
-  if not utils.in_mathzone() then
-    return
-  end
+    if not utils.in_mathzone() then return end
 
-  local math_node = utils.in_mathzone()
+    local math_node = utils.in_mathzone()
 
-  local srow, scol, erow, ecol = ts_utils.get_node_range(math_node)
+    local srow, scol, erow, ecol = ts_utils.get_node_range(math_node)
 
-  local lines = vim.api.nvim_buf_get_text(0, srow, scol, erow, ecol, {})
-  line = table.concat(lines, " ")
-  line = line:gsub("%$", "")
-  line = line:gsub("\\%[", "")
-  line = line:gsub("\\%]", "")
-  line = line:gsub("^\\%(", "")
-  line = line:gsub("\\%)$", "")
-  line = vim.trim(line)
-  if line == "" then
-      return
-  end
+    local lines = vim.api.nvim_buf_get_text(0, srow, scol, erow, ecol, {})
+    line = table.concat(lines, " ")
+    line = line:gsub("%$", "")
+    line = line:gsub("\\%[", "")
+    line = line:gsub("\\%]", "")
+    line = line:gsub("^\\%(", "")
+    line = line:gsub("\\%)$", "")
+    line = vim.trim(line)
+    if line == "" then return end
 
+    local success, exp = pcall(parser.parse_all, line)
 
+    if success and exp then
+        local succ, g = pcall(ascii.to_ascii, { exp }, 1)
+        if not succ then
+            print(g)
+            return 0
+        end
 
-  local success, exp = pcall(parser.parse_all, line)
+        if not g or g == "" then
+            vim.api.nvim_echo({ { "Empty expression detected. Please use the $...$ syntax.", "ErrorMsg" } }, false, {})
+            return 0
+        end
 
+        local drawing = {}
+        for row in vim.gsplit(tostring(g), "\n") do
+            table.insert(drawing, row)
+        end
+        if whitespace then
+            for i = 1, #drawing do
+                drawing[i] = whitespace .. drawing[i]
+            end
+        end
 
-  if success and exp then
-    local succ, g = pcall(ascii.to_ascii, {exp}, 1)
-    if not succ then
-      print(g)
-      return 0
+        local floating_default_options = {
+            wrap = false,
+            focusable = false,
+            border = "single",
+            stylize_markdown = false,
+        }
+        local bufnr_float, winr_float = vim.lsp.util.open_floating_preview(
+            drawing,
+            "markdown",
+            vim.tbl_deep_extend("force", floating_default_options, overrides or {})
+        )
+        local ns_id = vim.api.nvim_create_namespace("")
+        colorize(g, 0, 0, 0, ns_id, drawing, 0, 0, bufnr_float)
+    else
+        print(exp)
     end
-
-    if not g or g == "" then
-      vim.api.nvim_echo({{"Empty expression detected. Please use the $...$ syntax.", "ErrorMsg"}}, false, {})
-      return 0
-    end
-
-    local drawing = {}
-    for row in vim.gsplit(tostring(g), "\n") do
-    	table.insert(drawing, row)
-    end
-    if whitespace then
-    	for i=1,#drawing do
-    		drawing[i] = whitespace .. drawing[i]
-    	end
-    end
-
-
-
-
-    local floating_default_options = {
-      wrap = false,
-      focusable = false,
-      border = 'single',
-    	stylize_markdown=false
-    }
-    local bufnr_float, winr_float = vim.lsp.util.open_floating_preview(drawing, 'markdown', vim.tbl_deep_extend('force', floating_default_options, overrides or {}))
-    local ns_id = vim.api.nvim_create_namespace("")
-    colorize(g, 0, 0, 0, ns_id, drawing, 0, 0, bufnr_float)
-
-
-  else
-    print(exp)
-  end
-
 end
 
 function enable_virt(opts)
-  local buf = vim.api.nvim_get_current_buf()
-  virt_enabled[buf] = true
+    local buf = vim.api.nvim_get_current_buf()
+    virt_enabled[buf] = true
 
-	local inline_virt = {}
-	local virt_lines_above = {}
-	local virt_lines_below = {}
+    local inline_virt = {}
+    local virt_lines_above = {}
+    local virt_lines_below = {}
 
-	if mult_virt_ns[buf] then
-	  vim.api.nvim_buf_clear_namespace(buf, mult_virt_ns[buf], 0, -1)
-	end
-	mult_virt_ns[buf] = vim.api.nvim_create_namespace("")
+    if mult_virt_ns[buf] then vim.api.nvim_buf_clear_namespace(buf, mult_virt_ns[buf], 0, -1) end
+    mult_virt_ns[buf] = vim.api.nvim_create_namespace("")
 
-	local formula_nodes = utils.get_all_mathzones()
-	local formulas_loc = {}
-	for _, node in ipairs(formula_nodes) do
-	  local srow, scol, erow, ecol = ts_utils.get_node_range(node)
-		table.insert(formulas_loc, {srow, scol, erow, ecol})
-	end
+    local formula_nodes = utils.get_all_mathzones()
+    local formulas_loc = {}
+    for _, node in ipairs(formula_nodes) do
+        local srow, scol, erow, ecol = ts_utils.get_node_range(node)
+        table.insert(formulas_loc, { srow, scol, erow, ecol })
+    end
 
-  for _, loc in ipairs(formulas_loc) do
-    local srow, scol, erow, ecol = unpack(loc)
-  	local succ, texts = pcall(vim.api.nvim_buf_get_text, buf, srow, scol, erow, ecol, {})
-  	if succ then
-  		local line = table.concat(texts, " ")
-  		line = line:gsub("%$", "")
-  		line = line:gsub("\\%[", "")
-  		line = line:gsub("\\%]", "")
-  		line = line:gsub("^\\%(", "")
-  		line = line:gsub("\\%)$", "")
-  		line = vim.trim(line)
-  		local success, exp = pcall(parser.parse_all, line)
+    for _, loc in ipairs(formulas_loc) do
+        local srow, scol, erow, ecol = unpack(loc)
+        local succ, texts = pcall(vim.api.nvim_buf_get_text, buf, srow, scol, erow, ecol, {})
+        if succ then
+            local line = table.concat(texts, " ")
+            line = line:gsub("%$", "")
+            line = line:gsub("\\%[", "")
+            line = line:gsub("\\%]", "")
+            line = line:gsub("^\\%(", "")
+            line = line:gsub("\\%)$", "")
+            line = vim.trim(line)
+            local success, exp = pcall(parser.parse_all, line)
 
+            if success and exp then
+                local succ, g = pcall(ascii.to_ascii, { exp }, 1)
+                if not succ then
+                    print(g)
+                    return 0
+                end
 
-  		if success and exp then
-  			local succ, g = pcall(ascii.to_ascii, {exp}, 1)
-  			if not succ then
-  			  print(g)
-  			  return 0
-  			end
+                if not g or g == "" then
+                    vim.api.nvim_echo(
+                        { { "Empty expression detected. Please use the $...$ syntax.", "ErrorMsg" } },
+                        false,
+                        {}
+                    )
+                    return 0
+                end
 
-  			if not g or g == "" then
-  			  vim.api.nvim_echo({{"Empty expression detected. Please use the $...$ syntax.", "ErrorMsg"}}, false, {})
-  			  return 0
-  			end
+                local drawing = {}
+                for row in vim.gsplit(tostring(g), "\n") do
+                    table.insert(drawing, row)
+                end
+                if whitespace then
+                    for i = 1, #drawing do
+                        drawing[i] = whitespace .. drawing[i]
+                    end
+                end
 
-  			local drawing = {}
-  			for row in vim.gsplit(tostring(g), "\n") do
-  				table.insert(drawing, row)
-  			end
-  			if whitespace then
-  				for i=1,#drawing do
-  					drawing[i] = whitespace .. drawing[i]
-  				end
-  			end
+                local drawing_virt = {}
 
+                for j = 1, #drawing do
+                    local len = vim.str_utfindex(drawing[j])
+                    local new_virt_line = {}
+                    for i = 1, len do
+                        local a = vim.str_byteindex(drawing[j], i - 1)
+                        local b = vim.str_byteindex(drawing[j], i)
 
+                        local c = drawing[j]:sub(a + 1, b)
+                        table.insert(new_virt_line, { c, "Normal" })
+                    end
 
-  			local drawing_virt = {}
+                    table.insert(drawing_virt, new_virt_line)
+                end
 
-  			for j=1,#drawing do
-  			  local len = vim.str_utfindex(drawing[j])
-  			  local new_virt_line = {}
-  			  for i=1,len do
-  			    local a = vim.str_byteindex(drawing[j], i-1)
-  			    local b = vim.str_byteindex(drawing[j], i)
+                colorize_virt(g, drawing_virt, 0, 0, 0)
 
-  			    local c = drawing[j]:sub(a+1, b)
-  			    table.insert(new_virt_line, { c, "Normal" })
-  			  end
+                -- Pick the longest line in multiline formulas and hope that
+                -- everything fits horizontally
+                local concealline = srow
+                local longest = -1
+                for r = 1, erow - srow + 1 do
+                    local p1, p2
+                    if srow == erow then
+                        p1 = scol
+                        p2 = ecol
+                    elseif r == 1 then
+                        p1 = scol
+                        p2 = #vim.api.nvim_buf_get_lines(buf, srow, srow + 1, true)[1]
+                    elseif r == #drawing_virt then
+                        p1 = 0
+                        p2 = ecol
+                    else
+                        p1 = 0
+                        p2 = #vim.api.nvim_buf_get_lines(buf, srow + (r - 1), srow + (r - 1) + 1, true)[1]
+                    end
 
-  			  table.insert(drawing_virt, new_virt_line)
-  			end
+                    if p2 - p1 > longest then
+                        concealline = srow + (r - 1)
+                        longest = p2 - p1
+                    end
+                end
 
-  			colorize_virt(g, drawing_virt, 0, 0, 0)
+                for r, virt_line in ipairs(drawing_virt) do
+                    local relrow = r - g.my - 1
 
+                    if srow == 0 then relrow = r - 1 end
 
-  			-- Pick the longest line in multiline formulas and hope that
-  			-- everything fits horizontally
-  			local concealline = srow
-  			local longest = -1
-  			for r=1,erow-srow+1 do
-  				local p1, p2
-  				if srow == erow then
-  					p1 = scol
-  					p2 = ecol
-  				elseif r == 1 then
-  					p1 = scol
-  					p2 = #vim.api.nvim_buf_get_lines(buf, srow, srow+1, true)[1]
-  				elseif r == #drawing_virt then
-  					p1 = 0
-  					p2 = ecol
-  				else
-  					p1 = 0
-  					p2 = #vim.api.nvim_buf_get_lines(buf, srow+(r-1), srow+(r-1)+1, true)[1]
-  				end
+                    local p1, p2
+                    if srow == erow then
+                        p1 = scol
+                        p2 = ecol
+                    elseif r == 1 then
+                        p1 = scol
+                        p2 = #vim.api.nvim_buf_get_lines(buf, srow, srow + 1, true)[1]
+                    elseif r == #drawing_virt then
+                        p1 = 0
+                        p2 = ecol
+                    else
+                        p1 = 0
+                        p2 = #vim.api.nvim_buf_get_lines(buf, srow + (r - 1), srow + (r - 1) + 1, true)[1]
+                    end
 
-  				if p2 - p1 > longest then
-  					concealline = srow+(r-1)
-  					longest = p2 - p1
-  				end
-  			end
+                    local desired_col = p1 + 1
+                    if relrow == 0 then
+                        local chunks = {}
+                        local margin_left = desired_col - p1
+                        local margin_right = p2 - #virt_line - desired_col
 
-  			for r, virt_line in ipairs(drawing_virt) do
-  				local relrow = r - g.my - 1
+                        for i = 1, margin_left do
+                            table.insert(chunks, { " ", "NonText" })
+                        end
 
-  				if srow == 0 then
-  					relrow = r-1
-  				end
+                        vim.list_extend(chunks, virt_line)
 
-  				local p1, p2
-  				if srow == erow then
-  					p1 = scol
-  					p2 = ecol
-  				elseif r == 1 then
-  					p1 = scol
-  					p2 = #vim.api.nvim_buf_get_lines(buf, srow, srow+1, true)[1]
-  				elseif r == #drawing_virt then
-  					p1 = 0
-  					p2 = ecol
-  				else
-  					p1 = 0
-  					p2 = #vim.api.nvim_buf_get_lines(buf, srow+(r-1), srow+(r-1)+1, true)[1]
-  				end
+                        for i = 1, margin_right do
+                            table.insert(chunks, { " ", "NonText" })
+                        end
 
+                        table.insert(inline_virt, { chunks, concealline, p1, p2 })
+                    else
+                        local vline, virt_lines
+                        if relrow < 0 then
+                            virt_lines = virt_lines_above[concealline] or {}
+                            vline = virt_lines[-relrow] or {}
+                        else
+                            virt_lines = virt_lines_below[concealline] or {}
+                            vline = virt_lines[relrow] or {}
+                        end
 
+                        local col = #vline
+                        for i = 1, desired_col - col do
+                            table.insert(vline, { " ", "Normal" })
+                        end
 
-  				local desired_col = p1 + 1
-  				if relrow == 0 then
-  					local chunks = {}
-  					local margin_left = desired_col - p1
-  					local margin_right = p2 - #virt_line - desired_col
+                        vim.list_extend(vline, virt_line)
 
-  					for i=1,margin_left do
-  						table.insert(chunks, {" ", "NonText"})
-  					end
+                        if relrow < 0 then
+                            virt_lines[-relrow] = vline
+                            virt_lines_above[concealline] = virt_lines
+                        else
+                            virt_lines[relrow] = vline
+                            virt_lines_below[concealline] = virt_lines
+                        end
+                    end
+                end
 
-  					vim.list_extend(chunks, virt_line)
+                for r = 1, erow - srow + 1 do
+                    local p1, p2
+                    if srow == erow then
+                        p1 = scol
+                        p2 = ecol
+                    elseif r == 1 then
+                        p1 = scol
+                        p2 = #vim.api.nvim_buf_get_lines(buf, srow, srow + 1, true)[1]
+                    elseif r == #drawing_virt then
+                        p1 = 0
+                        p2 = ecol
+                    else
+                        p1 = 0
+                        p2 = #vim.api.nvim_buf_get_lines(buf, srow + (r - 1), srow + (r - 1) + 1, true)[1]
+                    end
 
-  					for i=1,margin_right do
-  						table.insert(chunks, {" ", "NonText"})
-  					end
+                    if srow + (r - 1) ~= concealline then
+                        local chunks = {}
+                        for i = 1, p2 - p1 do
+                            table.insert(chunks, { " ", "NonText" })
+                        end
 
-  					table.insert(inline_virt, { chunks, concealline, p1, p2 })
+                        table.insert(inline_virt, { chunks, srow + (r - 1), p1, p2 })
+                    end
+                end
+            else
+                if opts and opts.silent then
+                else
+                    print(exp)
+                end
+            end
+        end
+    end
 
-  				else 
-  					local vline, virt_lines
-  					if relrow < 0 then
-  						virt_lines = virt_lines_above[concealline] or {}
-  						vline = virt_lines[-relrow] or {}
-  					else
-  						virt_lines = virt_lines_below[concealline] or {}
-  						vline = virt_lines[relrow] or {}
-  					end
+    -- @place_drawings_above_lines
+    for _, conceal in ipairs(inline_virt) do
+        local chunks, row, p1, p2 = unpack(conceal)
 
-  					local col = #vline
-  					for i=1,desired_col-col do
-  						table.insert(vline, { " ", "Normal" })
-  					end
+        for j, chunk in ipairs(chunks) do
+            local c, hl_group = unpack(chunk)
+            if p1 + j == p2 and j < #chunks then hl_group = "DiffDelete" end
 
-  					vim.list_extend(vline, virt_line)
+            if p1 + j <= p2 then
+                vim.api.nvim_buf_set_extmark(buf, mult_virt_ns[buf], row, p1 + j - 1, {
+                    -- virt_text = {{ c, hl_group }},
+                    end_row = row,
+                    end_col = p1 + j,
+                    -- virt_text_pos = "overlay",
+                    conceal = c,
+                    hl_group = hl_group,
+                    strict = false,
+                })
+            end
+        end
+    end
 
-  					if relrow < 0 then
-  						virt_lines[-relrow] = vline
-  						virt_lines_above[concealline] = virt_lines
-  					else
-  						virt_lines[relrow] = vline
-  						virt_lines_below[concealline] = virt_lines
-  					end
+    for row, virt_lines in pairs(virt_lines_above) do
+        local virt_lines_reversed = {}
+        for _, line in ipairs(virt_lines) do
+            table.insert(virt_lines_reversed, 1, line)
+        end
 
-  				end
+        if #virt_lines_reversed > 0 then
+            vim.api.nvim_buf_set_extmark(buf, mult_virt_ns[buf], row, 0, {
+                virt_lines = virt_lines_reversed,
+                virt_lines_above = true,
+            })
+        end
+    end
 
-  			end
+    for row, virt_lines in pairs(virt_lines_below) do
+        if #virt_lines > 0 then
+            vim.api.nvim_buf_set_extmark(buf, mult_virt_ns[buf], row, 0, {
+                virt_lines = virt_lines,
+            })
+        end
+    end
 
-  			for r=1,erow-srow+1 do
-  				local p1, p2
-  				if srow == erow then
-  					p1 = scol
-  					p2 = ecol
-  				elseif r == 1 then
-  					p1 = scol
-  					p2 = #vim.api.nvim_buf_get_lines(buf, srow, srow+1, true)[1]
-  				elseif r == #drawing_virt then
-  					p1 = 0
-  					p2 = ecol
-  				else
-  					p1 = 0
-  					p2 = #vim.api.nvim_buf_get_lines(buf, srow+(r-1), srow+(r-1)+1, true)[1]
-  				end
+    local win = vim.api.nvim_get_current_win()
+    saved_conceallevel[win] = vim.wo[win].conceallevel
+    saved_concealcursor[win] = vim.wo[win].concealcursor
+    vim.wo[win].conceallevel = 2
+    vim.wo[win].concealcursor = ""
 
-  				if srow+(r-1) ~= concealline then
-  					local chunks = {}
-  					for i=1,p2-p1 do
-  						table.insert(chunks, {" ", "NonText"})
-  					end
+    local win = vim.api.nvim_get_current_win()
+    saved_wrapsettings[win] = vim.wo[win].wrap
+    vim.wo[win].wrap = false
 
-  					table.insert(inline_virt, { chunks, srow+(r-1), p1, p2 })
-  				end
-  			end
-
-
-  		else
-  			if opts and opts.silent then
-  			else
-  				print(exp)
-  			end
-  		end
-  	end
-  end
-
-  -- @place_drawings_above_lines
-	for _, conceal in ipairs(inline_virt) do
-		local chunks, row, p1, p2 = unpack(conceal)
-
-	  for j, chunk in ipairs(chunks) do
-	    local c, hl_group = unpack(chunk)
-			if p1+j == p2 and j < #chunks then
-				hl_group = "DiffDelete"
-			end
-
-			if p1+j <= p2 then
-				vim.api.nvim_buf_set_extmark(buf, mult_virt_ns[buf], row, p1+j-1, {
-					-- virt_text = {{ c, hl_group }},
-					end_row = row,
-					end_col = p1+j,
-					-- virt_text_pos = "overlay",
-					conceal = c,
-					hl_group = hl_group,
-					strict = false,
-				})
-			end
-	  end
-	end
-
-	for row, virt_lines in pairs(virt_lines_above) do
-		local virt_lines_reversed = {}
-		for _, line in ipairs(virt_lines) do
-			table.insert(virt_lines_reversed, 1, line)
-		end
-
-		if #virt_lines_reversed > 0 then
-			vim.api.nvim_buf_set_extmark(buf, mult_virt_ns[buf], row, 0, {
-				virt_lines = virt_lines_reversed,
-				virt_lines_above = true,
-			})
-		end
-	end
-
-	for row, virt_lines in pairs(virt_lines_below) do
-		if #virt_lines > 0 then
-			vim.api.nvim_buf_set_extmark(buf, mult_virt_ns[buf], row, 0, {
-				virt_lines = virt_lines,
-			})
-		end
-	end
-
-  local win = vim.api.nvim_get_current_win()
-  saved_conceallevel[win] = vim.wo[win].conceallevel
-  saved_concealcursor[win] = vim.wo[win].concealcursor
-  vim.wo[win].conceallevel = 2
-  vim.wo[win].concealcursor = ""
-
-	local win = vim.api.nvim_get_current_win()
-	saved_wrapsettings[win] = vim.wo[win].wrap
-	vim.wo[win].wrap = false
-
-	if opts and opts.autogen then
-		autogen_autocmd[buf] = vim.api.nvim_create_autocmd({"InsertLeave"}, {
-			buffer = buf,
-			desc = "nabla.nvim: Regenerates virt_lines automatically when the user exists insert mode",
-			callback = function()
-				autogen_flag = true
-				disable_virt()
-				autogen_flag = false
-				enable_virt()
-			end
-		})
-
-	end
+    if opts and opts.autogen then
+        autogen_autocmd[buf] = vim.api.nvim_create_autocmd({ "InsertLeave" }, {
+            buffer = buf,
+            desc = "nabla.nvim: Regenerates virt_lines automatically when the user exists insert mode",
+            callback = function()
+                autogen_flag = true
+                disable_virt()
+                autogen_flag = false
+                enable_virt()
+            end,
+        })
+    end
 end
 
 function disable_virt()
-  local buf = vim.api.nvim_get_current_buf()
-  virt_enabled[buf] = false
+    local buf = vim.api.nvim_get_current_buf()
+    virt_enabled[buf] = false
 
-  if mult_virt_ns[buf] then
-    vim.api.nvim_buf_clear_namespace(buf, mult_virt_ns[buf], 0, -1)
-    mult_virt_ns[buf] = nil
-  end
-  local win = vim.api.nvim_get_current_win()
-  if saved_conceallevel[win] then
-    vim.wo[win].conceallevel = saved_conceallevel[win]
-  end
-  if saved_concealcursor[win] then
-    vim.wo[win].concealcursor = saved_concealcursor[win]
-  end
+    if mult_virt_ns[buf] then
+        vim.api.nvim_buf_clear_namespace(buf, mult_virt_ns[buf], 0, -1)
+        mult_virt_ns[buf] = nil
+    end
+    local win = vim.api.nvim_get_current_win()
+    if saved_conceallevel[win] then vim.wo[win].conceallevel = saved_conceallevel[win] end
+    if saved_concealcursor[win] then vim.wo[win].concealcursor = saved_concealcursor[win] end
 
-	local win = vim.api.nvim_get_current_win()
-	if saved_wrapsettings[win] then
-	  vim.wo[win].wrap = saved_wrapsettings[win]
-	end
+    local win = vim.api.nvim_get_current_win()
+    if saved_wrapsettings[win] then vim.wo[win].wrap = saved_wrapsettings[win] end
 
-	if not autogen_flag and autogen_autocmd[buf] then
-		vim.api.nvim_del_autocmd(autogen_autocmd[buf])
-		autogen_autocmd[buf] = nil
-	end
+    if not autogen_flag and autogen_autocmd[buf] then
+        vim.api.nvim_del_autocmd(autogen_autocmd[buf])
+        autogen_autocmd[buf] = nil
+    end
 end
 
 function toggle_virt(opts)
-  local buf = vim.api.nvim_get_current_buf()
-  if virt_enabled[buf] then
-    disable_virt()
-  else
-    enable_virt(opts)
-  end
+    local buf = vim.api.nvim_get_current_buf()
+    if virt_enabled[buf] then
+        disable_virt()
+    else
+        enable_virt(opts)
+    end
 end
 
 function is_virt_enabled(buf)
-  buf = buf or vim.api.nvim_get_current_buf()
-  return virt_enabled[buf] == true
+    buf = buf or vim.api.nvim_get_current_buf()
+    return virt_enabled[buf] == true
 end
 
-
-
 return {
-	gen_drawing = gen_drawing,
-	popup= popup,
-	enable_virt = enable_virt,
+    gen_drawing = gen_drawing,
+    popup = popup,
+    enable_virt = enable_virt,
 
+    disable_virt = disable_virt,
 
-	disable_virt = disable_virt,
+    toggle_virt = toggle_virt,
 
-	toggle_virt = toggle_virt,
-
-	is_virt_enabled = is_virt_enabled,
-
+    is_virt_enabled = is_virt_enabled,
 }
-

--- a/lua/nabla/ascii.lua
+++ b/lua/nabla/ascii.lua
@@ -19,1968 +19,2036 @@ local put_if_only_sub
 
 local put_if_only_sup
 
-
 local style = {
-	div_high_bar = "‾",
-	div_middle_bar = "―",
-	div_low_bar = "_",
+    div_high_bar = "‾",
+    div_middle_bar = "―",
+    div_low_bar = "_",
 
-	left_top_par    = '⎛',
-	left_middle_par = '⎜',
-	left_bottom_par = '⎝',
+    left_top_par = "⎛",
+    left_middle_par = "⎜",
+    left_bottom_par = "⎝",
 
-	right_top_par    = '⎞',
-	right_middle_par = '⎟',
-	right_bottom_par = '⎠',
+    right_top_par = "⎞",
+    right_middle_par = "⎟",
+    right_bottom_par = "⎠",
 
-	left_single_par = '(',
-	right_single_par = ')',
+    left_single_par = "(",
+    right_single_par = ")",
 
-	comma_sign = ", ", 
+    comma_sign = ", ",
 
-	eq_sign = {
-		["="] = " = ",
-		["<"] = " < ",
-		[">"] = " > ",
-		[">="] = " ≥ ",
-		["<="] = " ≤ ",
-		[">>"] = " ≫ ",
-		["<<"] = " ≪ ",
-		["~="] = " ≈ ",
-		["!="] = " ≠ ",
-		["=>"] = " → ",
+    eq_sign = {
+        ["="] = " = ",
+        ["<"] = " < ",
+        [">"] = " > ",
+        [">="] = " ≥ ",
+        ["<="] = " ≤ ",
+        [">>"] = " ≫ ",
+        ["<<"] = " ≪ ",
+        ["~="] = " ≈ ",
+        ["!="] = " ≠ ",
+        ["=>"] = " → ",
+    },
 
-	},
+    prefix_minus_sign = "‐",
 
-	prefix_minus_sign = "‐",
+    root_vert_bar = "│",
+    root_bottom = "\\",
+    root_upper_left = "┌",
+    root_upper = "─",
+    root_upper_right = "┐",
 
-	root_vert_bar = "│",
-	root_bottom = "\\",
-	root_upper_left = "┌",
-	root_upper = "─",
-	root_upper_right = "┐",
+    matrix_upper_left = "⎡",
+    matrix_upper_right = "⎤",
+    matrix_vert_left = "⎢",
+    matrix_lower_left = "⎣",
+    matrix_lower_right = "⎦",
+    matrix_vert_right = "⎥",
+    matrix_single_left = "[",
+    matrix_single_right = "]",
 
-	matrix_upper_left = "⎡", 
-	matrix_upper_right = "⎤", 
-	matrix_vert_left = "⎢",
-	matrix_lower_left = "⎣", 
-	matrix_lower_right = "⎦", 
-	matrix_vert_right = "⎥",
-	matrix_single_left = "[",
-	matrix_single_right = "]",
+    left_top_bra = "⎧",
+    left_middle_bra = "⎨",
+    left_other_bra = "⎥",
+    left_bottom_bra = "⎩",
 
-	left_top_bra    = '⎧',
-	left_middle_bra = '⎨',
-	left_other_bra  = '⎥',
-	left_bottom_bra = '⎩',
+    right_top_bra = "⎫",
+    right_middle_bra = "⎬",
+    right_other_bra = "⎪",
+    right_bottom_bra = "⎭",
 
-	right_top_bra    = '⎫',
-	right_middle_bra = '⎬',
-	right_other_bra =  '⎪',
-	right_bottom_bra = '⎭',
+    left_single_bra = "{",
+    right_single_bra = "}",
 
-	left_single_bra = '{',
-	right_single_bra = '}',
-
-	vec_arrow = "→",
-
+    vec_arrow = "→",
 }
 
 local greek_etc = {
-  ["Alpha"] = "Α", ["Beta"] = "Β", ["Gamma"] = "Γ", ["Delta"] = "Δ", ["Epsilon"] = "Ε", ["Zeta"] = "Ζ", ["Eta"] = "Η", ["Theta"] = "Θ", ["Iota"] = "Ι", ["Kappa"] = "Κ", ["Lambda"] = "Λ", ["Mu"] = "Μ", ["Nu"] = "Ν", ["Xi"] = "Ξ", ["Omicron"] = "Ο", ["Pi"] = "Π", ["Rho"] = "Ρ", ["Sigma"] = "Σ", ["Tau"] = "Τ", ["Upsilon"] = "Υ", ["Phi"] = "Φ", ["Chi"] = "Χ", ["Psi"] = "Ψ", ["Omega"] = "Ω",
+    ["Alpha"] = "Α",
+    ["Beta"] = "Β",
+    ["Gamma"] = "Γ",
+    ["Delta"] = "Δ",
+    ["Epsilon"] = "Ε",
+    ["Zeta"] = "Ζ",
+    ["Eta"] = "Η",
+    ["Theta"] = "Θ",
+    ["Iota"] = "Ι",
+    ["Kappa"] = "Κ",
+    ["Lambda"] = "Λ",
+    ["Mu"] = "Μ",
+    ["Nu"] = "Ν",
+    ["Xi"] = "Ξ",
+    ["Omicron"] = "Ο",
+    ["Pi"] = "Π",
+    ["Rho"] = "Ρ",
+    ["Sigma"] = "Σ",
+    ["Tau"] = "Τ",
+    ["Upsilon"] = "Υ",
+    ["Phi"] = "Φ",
+    ["Chi"] = "Χ",
+    ["Psi"] = "Ψ",
+    ["Omega"] = "Ω",
 
-  ["alpha"] = "α", ["beta"] = "β", ["gamma"] = "γ", ["delta"] = "δ", ["epsilon"] = "ε", ["zeta"] = "ζ", ["eta"] = "η", ["theta"] = "θ", ["iota"] = "ι", ["kappa"] = "κ", ["lambda"] = "λ", ["mu"] = "μ", ["nu"] = "ν", ["xi"] = "ξ", ["omicron"] = "ο", ["pi"] = "π", ["rho"] = "ρ", ["final"] = "ς", ["sigma"] = "σ", ["tau"] = "τ", ["upsilon"] = "υ", ["phi"] = "φ", ["chi"] = "χ", ["psi"] = "ψ", ["omega"] = "ω",
+    ["alpha"] = "α",
+    ["beta"] = "β",
+    ["gamma"] = "γ",
+    ["delta"] = "δ",
+    ["epsilon"] = "ε",
+    ["zeta"] = "ζ",
+    ["eta"] = "η",
+    ["theta"] = "θ",
+    ["iota"] = "ι",
+    ["kappa"] = "κ",
+    ["lambda"] = "λ",
+    ["mu"] = "μ",
+    ["nu"] = "ν",
+    ["xi"] = "ξ",
+    ["omicron"] = "ο",
+    ["pi"] = "π",
+    ["rho"] = "ρ",
+    ["final"] = "ς",
+    ["sigma"] = "σ",
+    ["tau"] = "τ",
+    ["upsilon"] = "υ",
+    ["phi"] = "φ",
+    ["chi"] = "χ",
+    ["psi"] = "ψ",
+    ["omega"] = "ω",
 
-  ["nabla"] = "∇",
-
+    ["nabla"] = "∇",
 }
 
 local special_nums = {
-  ["infty"] = "∞",
-
+    ["infty"] = "∞",
 }
 
 local special_syms = {
-	["..."] = "…",
+    ["..."] = "…",
 
-	["cdot"] = "∙",
-	["approx"] = "≈",
-	["simeq"] = "≃",
-	["sim"] = "∼",
-	["propto"] = "∝",
-	["neq"] = "≠",
-	["doteq"] = "≐",
-	["leq"] = "≤",
-	["cong"] = "≅",
+    ["cdot"] = "∙",
+    ["approx"] = "≈",
+    ["simeq"] = "≃",
+    ["sim"] = "∼",
+    ["propto"] = "∝",
+    ["neq"] = "≠",
+    ["doteq"] = "≐",
+    ["leq"] = "≤",
+    ["cong"] = "≅",
 
-		["pm"] = "±",
-		["mp"] = "∓",
-		["to"] = "→",
+    ["pm"] = "±",
+    ["mp"] = "∓",
+    ["to"] = "→",
 
-	["rightarrow"] = "→",
-	["implies"] = "→",
-	["leftarrow"] = "⭠",
-	["ast"] = "∗",
+    ["rightarrow"] = "→",
+    ["implies"] = "→",
+    ["leftarrow"] = "⭠",
+    ["ast"] = "∗",
 
-	["partial"] = "∂",
+    ["partial"] = "∂",
 
-	["otimes"] = "⊗",
-	["oplus"] = "⊕",
-	["times"] = "⨯",
-	["perp"] = "⟂",
-	["circ"] = "∘",
-	["langle"] = "⟨",
-	["rangle"] = "⟩",
-	["dagger"] = "†",
-	["intercal"] = "⊺",
-	["wedge"] = "∧",
-	["vert"] = "|",
-	["Vert"] = "‖",
-	["C"] = "ℂ",
-	["N"] = "ℕ",
-	["Q"] = "ℚ",
-	["R"] = "ℝ",
-	["Z"] = "ℤ",
-	["qed"] = "∎",
-	["AA"] = "Å",
-	["aa"] = "å",
-	["ae"] = "æ",
-	["AE"] = "Æ",
-	["aleph"] = "ℵ",
-	["allequal"] = "≌",
-	["amalg"] = "⨿",
-	["angle"] = "∠",
-	["Angle"] = "⦜",
-	["approxeq"] = "≊",
-	["approxnotequal"] = "≆",
-	["aquarius"] = "♒",
-	["arccos"] = "arccos",
-	["arccot"] = "arccot",
-	["arcsin"] = "arcsin",
-	["arctan"] = "arctan",
-	["aries"] = "♈",
-	["arrowwaveright"] = "↜",
-	["asymp"] = "≍",
-	["backepsilon"] = "϶",
-	["backprime"] = "‵",
-	["backsimeq"] = "⋍",
-	["backsim"] = "∽",
-	["backslash"] = "⧵",
-	["barwedge"] = "⌅",
-	["because"] = "∵",
-	["beth"] = "ℶ",
-	["between"] = "≬",
-	["bigcap"] = "⋂",
-	["bigcirc"] = "○",
-	["bigcup"] = "⋃",
-	["bigtriangledown"] = "▽",
-	["bigtriangleup"] = "△",
-	["blacklozenge"] = "⧫",
-	["blacksquare"] = "■",
-	["blacktriangledown"] = "▾",
-	["blacktriangleleft"] = "◂",
-	["blacktriangleright"] = "▸",
-	["blacktriangle"] = "▴",
-	["bot"] = "⊥",
-	["bowtie"] = "⋈",
-	["boxdot"] = "⊡",
-	["boxminus"] = "⊟",
-	["boxplus"] = "⊞",
-	["boxtimes"] = "⊠",
-	["Box"] = "□",
-	["bullet"] = "∙",
-	["bumpeq"] = "≏",
-	["Bumpeq"] = "≎",
-	["cancer"] = "♋",
-	["capricornus"] = "♑",
-	["cap"] = "∩",
-	["Cap"] = "⋒",
-	["circeq"] = "≗",
-	["circlearrowleft"] = "↺",
-	["circlearrowright"] = "↻",
-	["circledast"] = "⊛",
-	["circledcirc"] = "⊚",
-	["circleddash"] = "⊝",
-	["circledS"] = "Ⓢ",
-	["clockoint"] = "⨏",
-	["clubsuit"] = "♣",
-	["clwintegral"] = "∱",
-	["Colon"] = "∷",
-	["complement"] = "∁",
-	["coprod"] = "∐",
-	["copyright"] = "©",
-	["cosh"] = "cosh",
-	["cos"] = "cos",
-	["coth"] = "coth",
-	["cot"] = "cot",
-	["csc"] = "csc",
-	["cup"] = "∪",
-	["Cup"] = "⋓",
-	["curlyeqprec"] = "⋞",
-	["curlyeqsucc"] = "⋟",
-	["curlyvee"] = "⋎",
-	["curlywedge"] = "⋏",
-	["curvearrowleft"] = "↶",
-	["curvearrowright"] = "↷",
-	["daleth"] = "ℸ",
-	["dashv"] = "⊣",
-	["dblarrowupdown"] = "⇅",
-	["ddagger"] = "‡",
-	["dh"] = "ð",
-	["DH"] = "Ð",
-	["diagup"] = "╱",
-	["diamondsuit"] = "♢",
-	["diamond"] = "⋄",
-	["Diamond"] = "◇",
-	["digamma"] = "ϝ",
-	["Digamma"] = "Ϝ",
-	["divideontimes"] = "⋇",
-	["div"] = "÷",
-	["dj"] = "đ",
-	["DJ"] = "Đ",
-	["doteqdot"] = "≑",
-	["dotplus"] = "∔",
-	["DownArrowBar"] = "⤓",
-	["downarrow"] = "↓",
-	["Downarrow"] = "⇓",
-	["DownArrowUpArrow"] = "⇵",
-	["downdownarrows"] = "⇊",
-	["downharpoonleft"] = "⇃",
-	["downharpoonright"] = "⇂",
-	["DownLeftRightVector"] = "⥐",
-	["DownLeftTeeVector"] = "⥞",
-	["DownLeftVectorBar"] = "⥖",
-	["DownRightTeeVector"] = "⥟",
-	["DownRightVectorBar"] = "⥗",
-	["downslopeellipsis"] = "⋱",
-	["eighthnote"] = "♪",
-	["ell"] = "ℓ",
-	["Elolarr"] = "⥀",
-	["Elorarr"] = "⥁",
-	["ElOr"] = "⩖",
-	["Elroang"] = "⦆",
-	["Elxsqcup"] = "⨆",
-	["Elxuplus"] = "⨄",
-	["ElzAnd"] = "⩓",
-	["Elzbtdl"] = "ɬ",
-	["ElzCint"] = "⨍",
-	["Elzcirfb"] = "◒",
-	["Elzcirfl"] = "◐",
-	["Elzcirfr"] = "◑",
-	["Elzclomeg"] = "ɷ",
-	["Elzddfnc"] = "⦙",
-	["Elzdefas"] = "⧋",
-	["Elzdlcorn"] = "⎣",
-	["Elzdshfnc"] = "┆",
-	["Elzdyogh"] = "ʤ",
-	["Elzesh"] = "ʃ",
-	["Elzfhr"] = "ɾ",
-	["Elzglst"] = "ʔ",
-	["Elzhlmrk"] = "ˑ",
-	["ElzInf"] = "⨇",
-	["Elzinglst"] = "ʖ",
-	["Elzinvv"] = "ʌ",
-	["Elzinvw"] = "ʍ",
-	["ElzLap"] = "⧊",
-	["Elzlmrk"] = "ː",
-	["Elzlow"] = "˕",
-	["Elzlpargt"] = "⦠",
-	["Elzltlmr"] = "ɱ",
-	["Elzltln"] = "ɲ",
-	["Elzminhat"] = "⩟",
-	["Elzopeno"] = "ɔ",
-	["ElzOr"] = "⩔",
-	["Elzpbgam"] = "ɤ",
-	["Elzpgamma"] = "ɣ",
-	["Elzpscrv"] = "ʋ",
-	["Elzpupsil"] = "ʊ",
-	["Elzrais"] = "˔",
-	["Elzrarrx"] = "⥇",
-	["Elzreapos"] = "‛",
-	["Elzreglst"] = "ʕ",
-	["ElzrLarr"] = "⥄",
-	["ElzRlarr"] = "⥂",
-	["Elzrl"] = "ɼ",
-	["Elzrtld"] = "ɖ",
-	["Elzrtll"] = "ɭ",
-	["Elzrtln"] = "ɳ",
-	["Elzrtlr"] = "ɽ",
-	["Elzrtls"] = "ʂ",
-	["Elzrtlt"] = "ʈ",
-	["Elzrtlz"] = "ʐ",
-	["Elzrttrnr"] = "ɻ",
-	["Elzrvbull"] = "◘",
-	["Elzsblhr"] = "˓",
-	["Elzsbrhr"] = "˒",
-	["Elzschwa"] = "ə",
-	["Elzsqfl"] = "◧",
-	["Elzsqfnw"] = "┙",
-	["Elzsqfr"] = "◨",
-	["Elzsqfse"] = "◪",
-	["Elzsqspne"] = "⋥",
-	["ElzSup"] = "⨈",
-	["Elztdcol"] = "⫶",
-	["Elztesh"] = "ʧ",
-	["Elztfnc"] = "⦀",
-	["ElzThr"] = "⨅",
-	["ElzTimes"] = "⨯",
-	["Elztrna"] = "ɐ",
-	["Elztrnh"] = "ɥ",
-	["Elztrnmlr"] = "ɰ",
-	["Elztrnm"] = "ɯ",
-	["Elztrnrl"] = "ɺ",
-	["Elztrnr"] = "ɹ",
-	["Elztrnsa"] = "ɒ",
-	["Elztrnt"] = "ʇ",
-	["Elztrny"] = "ʎ",
-	["Elzverti"] = "ˌ",
-	["Elzverts"] = "ˈ",
-	["Elzvrecto"] = "▯",
-	["Elzxh"] = "ħ",
-	["Elzxrat"] = "℞",
-	["Elzyogh"] = "ʒ",
-	["emptyset"] = "∅",
-	["eqcirc"] = "≖",
-	["eqslantgtr"] = "⪖",
-	["eqslantless"] = "⪕",
-	["Equal"] = "⩵",
-	["equiv"] = "≡",
-	["estimates"] = "≙",
-	["eth"] = "ð",
-	["exists"] = "∃",
-	["fallingdotseq"] = "≒",
-	["flat"] = "♭",
-	["forall"] = "∀",
-	["forcesextra"] = "⊨",
-	["frown"] = "⌢",
-	["gemini"] = "♊",
-	["geqq"] = "≧",
-	["geqslant"] = "⩾",
-	["geq"] = "≥",
-	["gets"] = "⟵",
-	["ge"] = "≥",
-	["gg"] = "≫",
-	["gimel"] = "ℷ",
-	["gnapprox"] = "⪊",
-	["gneqq"] = "≩",
-	["gneq"] = "⪈",
-	["gnsim"] = "⋧",
-	["greaterequivlnt"] = "≳",
-	["gtrapprox"] = "⪆",
-	["gtrdot"] = "⋗",
-	["gtreqless"] = "⋛",
-	["gtreqqless"] = "⪌",
-	["gtrless"] = "≷",
-	["guillemotleft"] = "«",
-	["guillemotright"] = "»",
-	["guilsinglleft"] = "‹",
-	["guilsinglright"] = "›",
-	["hbar"] = "ℏ",
-	["heartsuit"] = "♡",
-	["hermitconjmatrix"] = "⊹",
-	["homothetic"] = "∻",
-	["hookleftarrow"] = "↩",
-	["hookrightarrow"] = "↪",
-	["hslash"] = "ℏ",
-	["idotsint"] = "∫⋯∫",
-	["iff"] = "⟺",
-	["image"] = "⊷",
-	["imath"] = "ı",
-	["Im"] = "ℑ",
-	["in"] = "∈",
-	["varin"] = "𝛜",
-	["jmath"] = "ȷ",
-	["Join"] = "⋈",
-	["jupiter"] = "♃",
-	["Koppa"] = "Ϟ",
-	["land"] = "∧",
-	["lazysinv"] = "∾",
-	["lbrace"] = "{",
-	["lceil"] = "⌈",
-	["leadsto"] = "↝",
-	["leftarrowtail"] = "↢",
-	["Leftarrow"] = "⇐",
-	["LeftDownTeeVector"] = "⥡",
-	["LeftDownVectorBar"] = "⥙",
-	["leftharpoondown"] = "↽",
-	["leftharpoonup"] = "↼",
-	["leftleftarrows"] = "⇇",
-	["leftrightarrows"] = "⇆",
-	["leftrightarrow"] = "↔",
-	["Leftrightarrow"] = "⇔",
-	["leftrightharpoons"] = "⇋",
-	["leftrightsquigarrow"] = "↭",
-	["LeftRightVector"] = "⥎",
-	["LeftTeeVector"] = "⥚",
-	["leftthreetimes"] = "⋋",
-	["LeftTriangleBar"] = "⧏",
-	["LeftUpDownVector"] = "⥑",
-	["LeftUpTeeVector"] = "⥠",
-	["LeftUpVectorBar"] = "⥘",
-	["LeftVectorBar"] = "⥒",
-	["leo"] = "♌",
-	["leqq"] = "≦",
-	["leqslant"] = "⩽",
-	["lessapprox"] = "⪅",
-	["lessdot"] = "⋖",
-	["lesseqgtr"] = "⋚",
-	["lesseqqgtr"] = "⪋",
-	["lessequivlnt"] = "≲",
-	["lessgtr"] = "≶",
-	["le"] = "≤",
-	["lfloor"] = "⌊",
-	["lhd"] = "⊲",
-	["libra"] = "♎",
-	["llcorner"] = "⌞",
-	["Lleftarrow"] = "⇚",
-	["ll"] = "≪",
-	["lmoustache"] = "⎰",
-	["lnapprox"] = "⪉",
-	["lneqq"] = "≨",
-	["lneq"] = "⪇",
-	["lnot"] = "¬",
-	["lnsim"] = "≴",
-	["longleftarrow"] = "⟵",
-	["Longleftarrow"] = "⇐",
-	["longleftrightarrow"] = "↔",
-	["Longleftrightarrow"] = "⇔",
-	["longmapsto"] = "⇖",
-	["longrightarrow"] = "⟶",
-	["Longrightarrow"] = "⇒",
-	["looparrowleft"] = "↫",
-	["looparrowright"] = "↬",
-	["lor"] = "∨",
-	["lozenge"] = "◊",
-	["lrcorner"] = "⌟",
-	["Lsh"] = "↰",
-	["ltimes"] = "⋉",
-	["l"] = "ł",
-	["L"] = "Ł",
-	["male"] = "♂",
-	["mapsto"] = "↦",
-	["measuredangle"] = "∡",
-	["mercury"] = "☿",
-	["mho"] = "℧",
-	["mid"] = "∣",
-	["models"] = "⊨",
-	["multimap"] = "⊸",
-	["natural"] = "♮",
-	["nearrow"] = "↗",
-	["neg"] = "¬",
-	["neptune"] = "♆",
-	["NestedGreaterGreater"] = "⪢",
-	["NestedLessLess"] = "⪡",
-	["nexists"] = "∄",
-	["ngeq"] = "≠",
-	["ngtr"] = "≯",
-	["ng"] = "ŋ",
-	["NG"] = "Ŋ",
-	["ni"] = "∋",
-	["nleftarrow"] = "↚",
-	["nLeftarrow"] = "⇍",
-	["nleftrightarrow"] = "↮",
-	["nLeftrightarrow"] = "⇎",
-	["nleq"] = "≰",
-	["nless"] = "≮",
-	["nmid"] = "∤",
-	["notgreaterless"] = "≹",
-	["notin"] = "∉",
-	["notlessgreater"] = "≸",
-	["nparallel"] = "∦",
-	["nrightarrow"] = "↛",
-	["nRightarrow"] = "⇏",
-	["nsubseteq"] = "⊊",
-	["nsupseteq"] = "⊋",
-	["ntrianglelefteq"] = "⋬",
-	["ntriangleleft"] = "⋪",
-	["ntrianglerighteq"] = "⋭",
-	["ntriangleright"] = "⋫",
-	["nvdash"] = "⊬",
-	["nvDash"] = "⊭",
-	["nVdash"] = "⊮",
-	["nVDash"] = "⊯",
-	["nwarrow"] = "↖",
-	["odot"] = "⊙",
-	["oe"] = "œ",
-	["OE"] = "Œ",
-	["ominus"] = "⊖",
-	["openbracketleft"] = "〚",
-	["openbracketright"] = "〛",
-	["original"] = "⊶",
-	["oslash"] = "⊘",
-	["o"] = "ø",
-	["O"] = "Ø",
-	["perspcorrespond"] = "⌆",
-	["pisces"] = "♓",
-	["pitchfork"] = "⋔",
-	["pluto"] = "♇",
-	["precapprox"] = "≾",
-	["preccurlyeq"] = "≼",
-	["precedesnotsimilar"] = "⋨",
-	["preceq"] = "≼",
-	["precnapprox"] = "⪹",
-	["precneqq"] = "⪵",
-	["prime"] = "′",
-	["P"] = "¶",
-	["quarternote"] = "♩",
-	["rbrace"] = "}",
-	["rceil"] = "⌉",
-	["recorder"] = "⌕",
-	["Re"] = "ℜ",
-	["ReverseUpEquilibrium"] = "⥯",
-	["rfloor"] = "⌋",
-	["rhd"] = "⊳",
-	["rightanglearc"] = "⊾",
-	["rightangle"] = "∟",
-	["rightarrowtail"] = "↣",
-	["Rightarrow"] = "⇒",
-	["RightDownTeeVector"] = "⥝",
-	["RightDownVectorBar"] = "⥕",
-	["rightharpoondown"] = "⇁",
-	["rightharpoonup"] = "⇀",
-	["rightleftarrows"] = "⇄",
-	["rightleftharpoons"] = "⇌",
-	["rightmoon"] = "☾",
-	["rightrightarrows"] = "⇉",
-	["rightsquigarrow"] = "⇝",
-	["RightTeeVector"] = "⥛",
-	["rightthreetimes"] = "⋌",
-	["RightTriangleBar"] = "⧐",
-	["RightUpDownVector"] = "⥏",
-	["RightUpTeeVector"] = "⥜",
-	["RightUpVectorBar"] = "⥔",
-	["RightVectorBar"] = "⥓",
-	["risingdotseq"] = "≓",
-	["rmoustache"] = "⎱",
-	["RoundImplies"] = "⥰",
-	["Rrightarrow"] = "⇛",
-	["Rsh"] = "↱",
-	["rtimes"] = "⋊",
-	["RuleDelayed"] = "⧴",
-	["sagittarius"] = "♐",
-	["Sampi"] = "Ϡ",
-	["saturn"] = "♄",
-	["scorpio"] = "♏",
-	["searrow"] = "↘",
-	["sec"] = "sec",
-	["setminus"] = "∖",
-	["sharp"] = "♯",
-	["sinh"] = "sinh",
-	["sin"] = "sin",
-	["smile"] = "⌣",
-	["space"] = " ",
-	["spadesuit"] = "♠",
-	["sphericalangle"] = "∢",
-	["sqcap"] = "⊓",
-	["sqcup"] = "⊔",
-	["sqrint"] = "⨖",
-	["sqsubseteq"] = "⊑",
-	["sqsubset"] = "⊏",
-	["sqsupseteq"] = "⊒",
-	["sqsupset"] = "⊐",
-	["square"] = "□",
-	["ss"] = "ß",
-	["starequal"] = "≛",
-	["star"] = "⋆",
-	["Stigma"] = "Ϛ",
-	["S"] = "§",
-	["subseteqq"] = "⫅",
-	["subseteq"] = "⊆",
-	["subsetneqq"] = "⫋",
-	["subsetneq"] = "⊊",
-	["subset"] = "⊂",
-	["Subset"] = "⋐",
-	["succapprox"] = "≿",
-	["succcurlyeq"] = "≽",
-	["succeq"] = "≽",
-	["succnapprox"] = "⪺",
-	["succneqq"] = "⪶",
-	["succnsim"] = "⋩",
-	["succ"] = "≻",
-	["supseteqq"] = "⫆",
-	["supseteq"] = "⊇",
-	["supsetneqq"] = "⫌",
-	["supsetneq"] = "⊋",
-	["supset"] = "⊃",
-	["Supset"] = "⋑",
-	["surd"] = "√",
-	["surfintegral"] = "∯",
-	["swarrow"] = "↙",
-	["tanh"] = "tanh",
-	["tan"] = "tan",
-	["taurus"] = "♉",
-	["textasciiacute"] = "´",
-	["textasciibreve"] = "˘",
-	["textasciicaron"] = "ˇ",
-	["textasciidieresis"] = "¨",
-	["textasciigrave"] = "`",
-	["textasciimacron"] = "¯",
-	["textasciitilde"] = "~",
-	["textbackslash"] = "\\",
-	["textbrokenbar"] = "¦",
-	["textbullet"] = "•",
-	["textcent"] = "¢",
-	["textcopyright"] = "©",
-	["textcurrency"] = "¤",
-	["textdaggerdbl"] = "‡",
-	["textdagger"] = "†",
-	["textdegree"] = "°",
-	["textdollar"] = "$",
-	["textdoublepipe"] = "ǂ",
-	["textemdash"] = "—",
-	["textendash"] = "–",
-	["textexclamdown"] = "¡",
-	["texthvlig"] = "ƕ",
-	["textnrleg"] = "ƞ",
-	["textonehalf"] = "½",
-	["textonequarter"] = "¼",
-	["textordfeminine"] = "ª",
-	["textordmasculine"] = "º",
-	["textparagraph"] = "¶",
-	["textperiodcentered"] = "˙",
-	["textpertenthousand"] = "‱",
-	["textperthousand"] = "‰",
-	["textphi"] = "ɸ",
-	["textquestiondown"] = "¿",
-	["textquotedblleft"] = "“",
-	["textquotedblright"] = "”",
-	["textquotesingle"] = "'",
-	["textregistered"] = "®",
-	["textsection"] = "§",
-	["textsterling"] = "£",
-	["textTheta"] = "ϴ",
-	["texttheta"] = "θ",
-	["textthreequarters"] = "¾",
-	["texttildelow"] = "˜",
-	["texttimes"] = "×",
-	["texttrademark"] = "™",
-	["textturnk"] = "ʞ",
-	["textvartheta"] = "ϑ",
-	["textvisiblespace"] = "␣",
-	["textyen"] = "¥",
-	["therefore"] = "∴",
-	["th"] = "þ",
-	["TH"] = "Þ",
-	["tildetrpl"] = "≋",
-	["top"] = "⊤",
-	["triangledown"] = "▿",
-	["trianglelefteq"] = "⊴",
-	["triangleleft"] = "◁",
-	["triangleq"] = "≜",
-	["trianglerighteq"] = "⊵",
-	["triangleright"] = "▷",
-	["triangle"] = "△",
-	["truestate"] = "⊧",
-	["twoheadleftarrow"] = "↞",
-	["twoheadrightarrow"] = "↠",
-	["ulcorner"] = "⌜",
-	["unlhd"] = "⊴",
-	["unrhd"] = "⊵",
-	["UpArrowBar"] = "⤒",
-	["uparrow"] = "↑",
-	["Uparrow"] = "⇑",
-	["updownarrow"] = "↕",
-	["Updownarrow"] = "⇕",
-	["UpEquilibrium"] = "⥮",
-	["upharpoonleft"] = "↿",
-	["upharpoonright"] = "↾",
-	["uplus"] = "⊎",
-	["upslopeellipsis"] = "⋰",
-	["upuparrows"] = "⇈",
-	["uranus"] = "♅",
-	["urcorner"] = "⌝",
-	["varepsilon"] = "ɛ",
-	["varkappa"] = "ϰ",
-	["varnothing"] = "∅",
-	["varphi"] = "φ",
-	["varpi"] = "ϖ",
-	["varrho"] = "ϱ",
-	["varsigma"] = "ς",
-	["vartheta"] = "ϑ",
-	["vartriangleleft"] = "⊲",
-	["vartriangleright"] = "⊳",
-	["vartriangle"] = "▵",
-	["vdash"] = "⊢",
-	["Vdash"] = "⊩",
-	["VDash"] = "⊫",
-	["veebar"] = "⊻",
-	["vee"] = "∨",
-	["venus"] = "♀",
-	["verymuchgreater"] = "⋙",
-	["verymuchless"] = "⋘",
-	["virgo"] = "♍",
-	["volintegral"] = "∰",
-	["Vvdash"] = "⊪",
-	["wp"] = "℘",
-	["wr"] = "≀",
+    ["otimes"] = "⊗",
+    ["oplus"] = "⊕",
+    ["times"] = "⨯",
+    ["perp"] = "⟂",
+    ["circ"] = "∘",
+    ["langle"] = "⟨",
+    ["rangle"] = "⟩",
+    ["dagger"] = "†",
+    ["intercal"] = "⊺",
+    ["wedge"] = "∧",
+    ["vert"] = "|",
+    ["Vert"] = "‖",
+    ["C"] = "ℂ",
+    ["N"] = "ℕ",
+    ["Q"] = "ℚ",
+    ["R"] = "ℝ",
+    ["Z"] = "ℤ",
+    ["qed"] = "∎",
+    ["AA"] = "Å",
+    ["aa"] = "å",
+    ["ae"] = "æ",
+    ["AE"] = "Æ",
+    ["aleph"] = "ℵ",
+    ["allequal"] = "≌",
+    ["amalg"] = "⨿",
+    ["angle"] = "∠",
+    ["Angle"] = "⦜",
+    ["approxeq"] = "≊",
+    ["approxnotequal"] = "≆",
+    ["aquarius"] = "♒",
+    ["arccos"] = "arccos",
+    ["arccot"] = "arccot",
+    ["arcsin"] = "arcsin",
+    ["arctan"] = "arctan",
+    ["aries"] = "♈",
+    ["arrowwaveright"] = "↜",
+    ["asymp"] = "≍",
+    ["backepsilon"] = "϶",
+    ["backprime"] = "‵",
+    ["backsimeq"] = "⋍",
+    ["backsim"] = "∽",
+    ["backslash"] = "⧵",
+    ["barwedge"] = "⌅",
+    ["because"] = "∵",
+    ["beth"] = "ℶ",
+    ["between"] = "≬",
+    ["bigcap"] = "⋂",
+    ["bigcirc"] = "○",
+    ["bigcup"] = "⋃",
+    ["bigtriangledown"] = "▽",
+    ["bigtriangleup"] = "△",
+    ["blacklozenge"] = "⧫",
+    ["blacksquare"] = "■",
+    ["blacktriangledown"] = "▾",
+    ["blacktriangleleft"] = "◂",
+    ["blacktriangleright"] = "▸",
+    ["blacktriangle"] = "▴",
+    ["bot"] = "⊥",
+    ["bowtie"] = "⋈",
+    ["boxdot"] = "⊡",
+    ["boxminus"] = "⊟",
+    ["boxplus"] = "⊞",
+    ["boxtimes"] = "⊠",
+    ["Box"] = "□",
+    ["bullet"] = "∙",
+    ["bumpeq"] = "≏",
+    ["Bumpeq"] = "≎",
+    ["cancer"] = "♋",
+    ["capricornus"] = "♑",
+    ["cap"] = "∩",
+    ["Cap"] = "⋒",
+    ["circeq"] = "≗",
+    ["circlearrowleft"] = "↺",
+    ["circlearrowright"] = "↻",
+    ["circledast"] = "⊛",
+    ["circledcirc"] = "⊚",
+    ["circleddash"] = "⊝",
+    ["circledS"] = "Ⓢ",
+    ["clockoint"] = "⨏",
+    ["clubsuit"] = "♣",
+    ["clwintegral"] = "∱",
+    ["Colon"] = "∷",
+    ["complement"] = "∁",
+    ["coprod"] = "∐",
+    ["copyright"] = "©",
+    ["cosh"] = "cosh",
+    ["cos"] = "cos",
+    ["coth"] = "coth",
+    ["cot"] = "cot",
+    ["csc"] = "csc",
+    ["cup"] = "∪",
+    ["Cup"] = "⋓",
+    ["curlyeqprec"] = "⋞",
+    ["curlyeqsucc"] = "⋟",
+    ["curlyvee"] = "⋎",
+    ["curlywedge"] = "⋏",
+    ["curvearrowleft"] = "↶",
+    ["curvearrowright"] = "↷",
+    ["daleth"] = "ℸ",
+    ["dashv"] = "⊣",
+    ["dblarrowupdown"] = "⇅",
+    ["ddagger"] = "‡",
+    ["dh"] = "ð",
+    ["DH"] = "Ð",
+    ["diagup"] = "╱",
+    ["diamondsuit"] = "♢",
+    ["diamond"] = "⋄",
+    ["Diamond"] = "◇",
+    ["digamma"] = "ϝ",
+    ["Digamma"] = "Ϝ",
+    ["divideontimes"] = "⋇",
+    ["div"] = "÷",
+    ["dj"] = "đ",
+    ["DJ"] = "Đ",
+    ["doteqdot"] = "≑",
+    ["dotplus"] = "∔",
+    ["DownArrowBar"] = "⤓",
+    ["downarrow"] = "↓",
+    ["Downarrow"] = "⇓",
+    ["DownArrowUpArrow"] = "⇵",
+    ["downdownarrows"] = "⇊",
+    ["downharpoonleft"] = "⇃",
+    ["downharpoonright"] = "⇂",
+    ["DownLeftRightVector"] = "⥐",
+    ["DownLeftTeeVector"] = "⥞",
+    ["DownLeftVectorBar"] = "⥖",
+    ["DownRightTeeVector"] = "⥟",
+    ["DownRightVectorBar"] = "⥗",
+    ["downslopeellipsis"] = "⋱",
+    ["eighthnote"] = "♪",
+    ["ell"] = "ℓ",
+    ["Elolarr"] = "⥀",
+    ["Elorarr"] = "⥁",
+    ["ElOr"] = "⩖",
+    ["Elroang"] = "⦆",
+    ["Elxsqcup"] = "⨆",
+    ["Elxuplus"] = "⨄",
+    ["ElzAnd"] = "⩓",
+    ["Elzbtdl"] = "ɬ",
+    ["ElzCint"] = "⨍",
+    ["Elzcirfb"] = "◒",
+    ["Elzcirfl"] = "◐",
+    ["Elzcirfr"] = "◑",
+    ["Elzclomeg"] = "ɷ",
+    ["Elzddfnc"] = "⦙",
+    ["Elzdefas"] = "⧋",
+    ["Elzdlcorn"] = "⎣",
+    ["Elzdshfnc"] = "┆",
+    ["Elzdyogh"] = "ʤ",
+    ["Elzesh"] = "ʃ",
+    ["Elzfhr"] = "ɾ",
+    ["Elzglst"] = "ʔ",
+    ["Elzhlmrk"] = "ˑ",
+    ["ElzInf"] = "⨇",
+    ["Elzinglst"] = "ʖ",
+    ["Elzinvv"] = "ʌ",
+    ["Elzinvw"] = "ʍ",
+    ["ElzLap"] = "⧊",
+    ["Elzlmrk"] = "ː",
+    ["Elzlow"] = "˕",
+    ["Elzlpargt"] = "⦠",
+    ["Elzltlmr"] = "ɱ",
+    ["Elzltln"] = "ɲ",
+    ["Elzminhat"] = "⩟",
+    ["Elzopeno"] = "ɔ",
+    ["ElzOr"] = "⩔",
+    ["Elzpbgam"] = "ɤ",
+    ["Elzpgamma"] = "ɣ",
+    ["Elzpscrv"] = "ʋ",
+    ["Elzpupsil"] = "ʊ",
+    ["Elzrais"] = "˔",
+    ["Elzrarrx"] = "⥇",
+    ["Elzreapos"] = "‛",
+    ["Elzreglst"] = "ʕ",
+    ["ElzrLarr"] = "⥄",
+    ["ElzRlarr"] = "⥂",
+    ["Elzrl"] = "ɼ",
+    ["Elzrtld"] = "ɖ",
+    ["Elzrtll"] = "ɭ",
+    ["Elzrtln"] = "ɳ",
+    ["Elzrtlr"] = "ɽ",
+    ["Elzrtls"] = "ʂ",
+    ["Elzrtlt"] = "ʈ",
+    ["Elzrtlz"] = "ʐ",
+    ["Elzrttrnr"] = "ɻ",
+    ["Elzrvbull"] = "◘",
+    ["Elzsblhr"] = "˓",
+    ["Elzsbrhr"] = "˒",
+    ["Elzschwa"] = "ə",
+    ["Elzsqfl"] = "◧",
+    ["Elzsqfnw"] = "┙",
+    ["Elzsqfr"] = "◨",
+    ["Elzsqfse"] = "◪",
+    ["Elzsqspne"] = "⋥",
+    ["ElzSup"] = "⨈",
+    ["Elztdcol"] = "⫶",
+    ["Elztesh"] = "ʧ",
+    ["Elztfnc"] = "⦀",
+    ["ElzThr"] = "⨅",
+    ["ElzTimes"] = "⨯",
+    ["Elztrna"] = "ɐ",
+    ["Elztrnh"] = "ɥ",
+    ["Elztrnmlr"] = "ɰ",
+    ["Elztrnm"] = "ɯ",
+    ["Elztrnrl"] = "ɺ",
+    ["Elztrnr"] = "ɹ",
+    ["Elztrnsa"] = "ɒ",
+    ["Elztrnt"] = "ʇ",
+    ["Elztrny"] = "ʎ",
+    ["Elzverti"] = "ˌ",
+    ["Elzverts"] = "ˈ",
+    ["Elzvrecto"] = "▯",
+    ["Elzxh"] = "ħ",
+    ["Elzxrat"] = "℞",
+    ["Elzyogh"] = "ʒ",
+    ["emptyset"] = "∅",
+    ["eqcirc"] = "≖",
+    ["eqslantgtr"] = "⪖",
+    ["eqslantless"] = "⪕",
+    ["Equal"] = "⩵",
+    ["equiv"] = "≡",
+    ["estimates"] = "≙",
+    ["eth"] = "ð",
+    ["exists"] = "∃",
+    ["fallingdotseq"] = "≒",
+    ["flat"] = "♭",
+    ["forall"] = "∀",
+    ["forcesextra"] = "⊨",
+    ["frown"] = "⌢",
+    ["gemini"] = "♊",
+    ["geqq"] = "≧",
+    ["geqslant"] = "⩾",
+    ["geq"] = "≥",
+    ["gets"] = "⟵",
+    ["ge"] = "≥",
+    ["gg"] = "≫",
+    ["gimel"] = "ℷ",
+    ["gnapprox"] = "⪊",
+    ["gneqq"] = "≩",
+    ["gneq"] = "⪈",
+    ["gnsim"] = "⋧",
+    ["greaterequivlnt"] = "≳",
+    ["gtrapprox"] = "⪆",
+    ["gtrdot"] = "⋗",
+    ["gtreqless"] = "⋛",
+    ["gtreqqless"] = "⪌",
+    ["gtrless"] = "≷",
+    ["guillemotleft"] = "«",
+    ["guillemotright"] = "»",
+    ["guilsinglleft"] = "‹",
+    ["guilsinglright"] = "›",
+    ["hbar"] = "ℏ",
+    ["heartsuit"] = "♡",
+    ["hermitconjmatrix"] = "⊹",
+    ["homothetic"] = "∻",
+    ["hookleftarrow"] = "↩",
+    ["hookrightarrow"] = "↪",
+    ["hslash"] = "ℏ",
+    ["idotsint"] = "∫⋯∫",
+    ["iff"] = "⟺",
+    ["image"] = "⊷",
+    ["imath"] = "ı",
+    ["Im"] = "ℑ",
+    ["in"] = "∈",
+    ["varin"] = "𝛜",
+    ["jmath"] = "ȷ",
+    ["Join"] = "⋈",
+    ["jupiter"] = "♃",
+    ["Koppa"] = "Ϟ",
+    ["land"] = "∧",
+    ["lazysinv"] = "∾",
+    ["lbrace"] = "{",
+    ["lceil"] = "⌈",
+    ["leadsto"] = "↝",
+    ["leftarrowtail"] = "↢",
+    ["Leftarrow"] = "⇐",
+    ["LeftDownTeeVector"] = "⥡",
+    ["LeftDownVectorBar"] = "⥙",
+    ["leftharpoondown"] = "↽",
+    ["leftharpoonup"] = "↼",
+    ["leftleftarrows"] = "⇇",
+    ["leftrightarrows"] = "⇆",
+    ["leftrightarrow"] = "↔",
+    ["Leftrightarrow"] = "⇔",
+    ["leftrightharpoons"] = "⇋",
+    ["leftrightsquigarrow"] = "↭",
+    ["LeftRightVector"] = "⥎",
+    ["LeftTeeVector"] = "⥚",
+    ["leftthreetimes"] = "⋋",
+    ["LeftTriangleBar"] = "⧏",
+    ["LeftUpDownVector"] = "⥑",
+    ["LeftUpTeeVector"] = "⥠",
+    ["LeftUpVectorBar"] = "⥘",
+    ["LeftVectorBar"] = "⥒",
+    ["leo"] = "♌",
+    ["leqq"] = "≦",
+    ["leqslant"] = "⩽",
+    ["lessapprox"] = "⪅",
+    ["lessdot"] = "⋖",
+    ["lesseqgtr"] = "⋚",
+    ["lesseqqgtr"] = "⪋",
+    ["lessequivlnt"] = "≲",
+    ["lessgtr"] = "≶",
+    ["le"] = "≤",
+    ["lfloor"] = "⌊",
+    ["lhd"] = "⊲",
+    ["libra"] = "♎",
+    ["llcorner"] = "⌞",
+    ["Lleftarrow"] = "⇚",
+    ["ll"] = "≪",
+    ["lmoustache"] = "⎰",
+    ["lnapprox"] = "⪉",
+    ["lneqq"] = "≨",
+    ["lneq"] = "⪇",
+    ["lnot"] = "¬",
+    ["lnsim"] = "≴",
+    ["longleftarrow"] = "⟵",
+    ["Longleftarrow"] = "⇐",
+    ["longleftrightarrow"] = "↔",
+    ["Longleftrightarrow"] = "⇔",
+    ["longmapsto"] = "⇖",
+    ["longrightarrow"] = "⟶",
+    ["Longrightarrow"] = "⇒",
+    ["looparrowleft"] = "↫",
+    ["looparrowright"] = "↬",
+    ["lor"] = "∨",
+    ["lozenge"] = "◊",
+    ["lrcorner"] = "⌟",
+    ["Lsh"] = "↰",
+    ["ltimes"] = "⋉",
+    ["l"] = "ł",
+    ["L"] = "Ł",
+    ["male"] = "♂",
+    ["mapsto"] = "↦",
+    ["measuredangle"] = "∡",
+    ["mercury"] = "☿",
+    ["mho"] = "℧",
+    ["mid"] = "∣",
+    ["models"] = "⊨",
+    ["multimap"] = "⊸",
+    ["natural"] = "♮",
+    ["nearrow"] = "↗",
+    ["neg"] = "¬",
+    ["neptune"] = "♆",
+    ["NestedGreaterGreater"] = "⪢",
+    ["NestedLessLess"] = "⪡",
+    ["nexists"] = "∄",
+    ["ngeq"] = "≠",
+    ["ngtr"] = "≯",
+    ["ng"] = "ŋ",
+    ["NG"] = "Ŋ",
+    ["ni"] = "∋",
+    ["nleftarrow"] = "↚",
+    ["nLeftarrow"] = "⇍",
+    ["nleftrightarrow"] = "↮",
+    ["nLeftrightarrow"] = "⇎",
+    ["nleq"] = "≰",
+    ["nless"] = "≮",
+    ["nmid"] = "∤",
+    ["notgreaterless"] = "≹",
+    ["notin"] = "∉",
+    ["notlessgreater"] = "≸",
+    ["nparallel"] = "∦",
+    ["nrightarrow"] = "↛",
+    ["nRightarrow"] = "⇏",
+    ["nsubseteq"] = "⊊",
+    ["nsupseteq"] = "⊋",
+    ["ntrianglelefteq"] = "⋬",
+    ["ntriangleleft"] = "⋪",
+    ["ntrianglerighteq"] = "⋭",
+    ["ntriangleright"] = "⋫",
+    ["nvdash"] = "⊬",
+    ["nvDash"] = "⊭",
+    ["nVdash"] = "⊮",
+    ["nVDash"] = "⊯",
+    ["nwarrow"] = "↖",
+    ["odot"] = "⊙",
+    ["oe"] = "œ",
+    ["OE"] = "Œ",
+    ["ominus"] = "⊖",
+    ["openbracketleft"] = "〚",
+    ["openbracketright"] = "〛",
+    ["original"] = "⊶",
+    ["oslash"] = "⊘",
+    ["o"] = "ø",
+    ["O"] = "Ø",
+    ["perspcorrespond"] = "⌆",
+    ["pisces"] = "♓",
+    ["pitchfork"] = "⋔",
+    ["pluto"] = "♇",
+    ["precapprox"] = "≾",
+    ["preccurlyeq"] = "≼",
+    ["precedesnotsimilar"] = "⋨",
+    ["preceq"] = "≼",
+    ["precnapprox"] = "⪹",
+    ["precneqq"] = "⪵",
+    ["prime"] = "′",
+    ["P"] = "¶",
+    ["quarternote"] = "♩",
+    ["rbrace"] = "}",
+    ["rceil"] = "⌉",
+    ["recorder"] = "⌕",
+    ["Re"] = "ℜ",
+    ["ReverseUpEquilibrium"] = "⥯",
+    ["rfloor"] = "⌋",
+    ["rhd"] = "⊳",
+    ["rightanglearc"] = "⊾",
+    ["rightangle"] = "∟",
+    ["rightarrowtail"] = "↣",
+    ["Rightarrow"] = "⇒",
+    ["RightDownTeeVector"] = "⥝",
+    ["RightDownVectorBar"] = "⥕",
+    ["rightharpoondown"] = "⇁",
+    ["rightharpoonup"] = "⇀",
+    ["rightleftarrows"] = "⇄",
+    ["rightleftharpoons"] = "⇌",
+    ["rightmoon"] = "☾",
+    ["rightrightarrows"] = "⇉",
+    ["rightsquigarrow"] = "⇝",
+    ["RightTeeVector"] = "⥛",
+    ["rightthreetimes"] = "⋌",
+    ["RightTriangleBar"] = "⧐",
+    ["RightUpDownVector"] = "⥏",
+    ["RightUpTeeVector"] = "⥜",
+    ["RightUpVectorBar"] = "⥔",
+    ["RightVectorBar"] = "⥓",
+    ["risingdotseq"] = "≓",
+    ["rmoustache"] = "⎱",
+    ["RoundImplies"] = "⥰",
+    ["Rrightarrow"] = "⇛",
+    ["Rsh"] = "↱",
+    ["rtimes"] = "⋊",
+    ["RuleDelayed"] = "⧴",
+    ["sagittarius"] = "♐",
+    ["Sampi"] = "Ϡ",
+    ["saturn"] = "♄",
+    ["scorpio"] = "♏",
+    ["searrow"] = "↘",
+    ["sec"] = "sec",
+    ["setminus"] = "∖",
+    ["sharp"] = "♯",
+    ["sinh"] = "sinh",
+    ["sin"] = "sin",
+    ["smile"] = "⌣",
+    ["space"] = " ",
+    ["spadesuit"] = "♠",
+    ["sphericalangle"] = "∢",
+    ["sqcap"] = "⊓",
+    ["sqcup"] = "⊔",
+    ["sqrint"] = "⨖",
+    ["sqsubseteq"] = "⊑",
+    ["sqsubset"] = "⊏",
+    ["sqsupseteq"] = "⊒",
+    ["sqsupset"] = "⊐",
+    ["square"] = "□",
+    ["ss"] = "ß",
+    ["starequal"] = "≛",
+    ["star"] = "⋆",
+    ["Stigma"] = "Ϛ",
+    ["S"] = "§",
+    ["subseteqq"] = "⫅",
+    ["subseteq"] = "⊆",
+    ["subsetneqq"] = "⫋",
+    ["subsetneq"] = "⊊",
+    ["subset"] = "⊂",
+    ["Subset"] = "⋐",
+    ["succapprox"] = "≿",
+    ["succcurlyeq"] = "≽",
+    ["succeq"] = "≽",
+    ["succnapprox"] = "⪺",
+    ["succneqq"] = "⪶",
+    ["succnsim"] = "⋩",
+    ["succ"] = "≻",
+    ["supseteqq"] = "⫆",
+    ["supseteq"] = "⊇",
+    ["supsetneqq"] = "⫌",
+    ["supsetneq"] = "⊋",
+    ["supset"] = "⊃",
+    ["Supset"] = "⋑",
+    ["surd"] = "√",
+    ["surfintegral"] = "∯",
+    ["swarrow"] = "↙",
+    ["tanh"] = "tanh",
+    ["tan"] = "tan",
+    ["taurus"] = "♉",
+    ["textasciiacute"] = "´",
+    ["textasciibreve"] = "˘",
+    ["textasciicaron"] = "ˇ",
+    ["textasciidieresis"] = "¨",
+    ["textasciigrave"] = "`",
+    ["textasciimacron"] = "¯",
+    ["textasciitilde"] = "~",
+    ["textbackslash"] = "\\",
+    ["textbrokenbar"] = "¦",
+    ["textbullet"] = "•",
+    ["textcent"] = "¢",
+    ["textcopyright"] = "©",
+    ["textcurrency"] = "¤",
+    ["textdaggerdbl"] = "‡",
+    ["textdagger"] = "†",
+    ["textdegree"] = "°",
+    ["textdollar"] = "$",
+    ["textdoublepipe"] = "ǂ",
+    ["textemdash"] = "—",
+    ["textendash"] = "–",
+    ["textexclamdown"] = "¡",
+    ["texthvlig"] = "ƕ",
+    ["textnrleg"] = "ƞ",
+    ["textonehalf"] = "½",
+    ["textonequarter"] = "¼",
+    ["textordfeminine"] = "ª",
+    ["textordmasculine"] = "º",
+    ["textparagraph"] = "¶",
+    ["textperiodcentered"] = "˙",
+    ["textpertenthousand"] = "‱",
+    ["textperthousand"] = "‰",
+    ["textphi"] = "ɸ",
+    ["textquestiondown"] = "¿",
+    ["textquotedblleft"] = "“",
+    ["textquotedblright"] = "”",
+    ["textquotesingle"] = "'",
+    ["textregistered"] = "®",
+    ["textsection"] = "§",
+    ["textsterling"] = "£",
+    ["textTheta"] = "ϴ",
+    ["texttheta"] = "θ",
+    ["textthreequarters"] = "¾",
+    ["texttildelow"] = "˜",
+    ["texttimes"] = "×",
+    ["texttrademark"] = "™",
+    ["textturnk"] = "ʞ",
+    ["textvartheta"] = "ϑ",
+    ["textvisiblespace"] = "␣",
+    ["textyen"] = "¥",
+    ["therefore"] = "∴",
+    ["th"] = "þ",
+    ["TH"] = "Þ",
+    ["tildetrpl"] = "≋",
+    ["top"] = "⊤",
+    ["triangledown"] = "▿",
+    ["trianglelefteq"] = "⊴",
+    ["triangleleft"] = "◁",
+    ["triangleq"] = "≜",
+    ["trianglerighteq"] = "⊵",
+    ["triangleright"] = "▷",
+    ["triangle"] = "△",
+    ["truestate"] = "⊧",
+    ["twoheadleftarrow"] = "↞",
+    ["twoheadrightarrow"] = "↠",
+    ["ulcorner"] = "⌜",
+    ["unlhd"] = "⊴",
+    ["unrhd"] = "⊵",
+    ["UpArrowBar"] = "⤒",
+    ["uparrow"] = "↑",
+    ["Uparrow"] = "⇑",
+    ["updownarrow"] = "↕",
+    ["Updownarrow"] = "⇕",
+    ["UpEquilibrium"] = "⥮",
+    ["upharpoonleft"] = "↿",
+    ["upharpoonright"] = "↾",
+    ["uplus"] = "⊎",
+    ["upslopeellipsis"] = "⋰",
+    ["upuparrows"] = "⇈",
+    ["uranus"] = "♅",
+    ["urcorner"] = "⌝",
+    ["varepsilon"] = "ɛ",
+    ["varkappa"] = "ϰ",
+    ["varnothing"] = "∅",
+    ["varphi"] = "φ",
+    ["varpi"] = "ϖ",
+    ["varrho"] = "ϱ",
+    ["varsigma"] = "ς",
+    ["vartheta"] = "ϑ",
+    ["vartriangleleft"] = "⊲",
+    ["vartriangleright"] = "⊳",
+    ["vartriangle"] = "▵",
+    ["vdash"] = "⊢",
+    ["Vdash"] = "⊩",
+    ["VDash"] = "⊫",
+    ["veebar"] = "⊻",
+    ["vee"] = "∨",
+    ["venus"] = "♀",
+    ["verymuchgreater"] = "⋙",
+    ["verymuchless"] = "⋘",
+    ["virgo"] = "♍",
+    ["volintegral"] = "∰",
+    ["Vvdash"] = "⊪",
+    ["wp"] = "℘",
+    ["wr"] = "≀",
 
-	["cdots"] = "⋯",
-	["vdots"] = "⋮",
-	["ddots"] = "⋱",
-	["ldots"] = "…",
-	["dots"] = "…", -- alias to ldots (for the moment)
+    ["cdots"] = "⋯",
+    ["vdots"] = "⋮",
+    ["ddots"] = "⋱",
+    ["ldots"] = "…",
+    ["dots"] = "…", -- alias to ldots (for the moment)
 }
 
 local grid = {}
 function grid:new(w, h, content, t)
-	if not content and w and h and w > 0 and h > 0 then
-		content = {}
-		for y=1,h do
-			local row = ""
-			for x=1,w do
-				row = row .. " "
-			end
-			table.insert(content, row)
-		end
-	end
+    if not content and w and h and w > 0 and h > 0 then
+        content = {}
+        for y = 1, h do
+            local row = ""
+            for x = 1, w do
+                row = row .. " "
+            end
+            table.insert(content, row)
+        end
+    end
 
-	local o = { 
-		w = w or 0, 
-		h = h or 0, 
-    t = t,
-    children = {},
-		content = content or {},
-		my = 0, -- middle y (might not be h/2, for example fractions with big denominator, etc )
+    local o = {
+        w = w or 0,
+        h = h or 0,
+        t = t,
+        children = {},
+        content = content or {},
+        my = 0, -- middle y (might not be h/2, for example fractions with big denominator, etc )
+    }
+    return setmetatable(o, {
+        __tostring = function(g) return table.concat(g.content, "\n") end,
 
-	}
-	return setmetatable(o, { 
-		__tostring = function(g)
-			return table.concat(g.content, "\n")
-		end,
-
-		__index = grid,
-	})
+        __index = grid,
+    })
 end
 
 function grid:join_hori(g, top_align)
-	local combined = {}
+    local combined = {}
 
-	local num_max = math.max(self.my, g.my)
-	local den_max = math.max(self.h - self.my, g.h - g.my)
+    local num_max = math.max(self.my, g.my)
+    local den_max = math.max(self.h - self.my, g.h - g.my)
 
-	local s1, s2
-	if not top_align then
-		s1 = num_max - self.my
-		s2 = num_max - g.my
-	else
-		s1 = 0
-		s2 = 0
-	end
+    local s1, s2
+    if not top_align then
+        s1 = num_max - self.my
+        s2 = num_max - g.my
+    else
+        s1 = 0
+        s2 = 0
+    end
 
-	local h 
-	if not top_align then
-		h = den_max + num_max
-	else
-		h = math.max(self.h, g.h)
-	end
+    local h
+    if not top_align then
+        h = den_max + num_max
+    else
+        h = math.max(self.h, g.h)
+    end
 
+    for y = 1, h do
+        local r1 = self:get_row(y - s1)
+        local r2 = g:get_row(y - s2)
 
-	for y=1,h do
-		local r1 = self:get_row(y-s1)
-		local r2 = g:get_row(y-s2)
+        table.insert(combined, r1 .. r2)
+    end
 
-		table.insert(combined, r1 .. r2)
+    local c = grid:new(self.w + g.w, h, combined)
+    c.my = num_max
 
-	end
+    table.insert(c.children, { self, 0, s1 })
+    table.insert(c.children, { g, self.w, s2 })
 
-	local c = grid:new(self.w+g.w, h, combined)
-	c.my = num_max
-
-  table.insert(c.children, { self, 0, s1 })
-  table.insert(c.children, { g, self.w, s2 })
-
-	return c
+    return c
 end
 
 function grid:get_row(y)
-	if y < 1 or y > self.h then
-		local s = ""
-		for i=1,self.w do s = s .. " " end
-		return s
-	end
-	return self.content[y]
+    if y < 1 or y > self.h then
+        local s = ""
+        for i = 1, self.w do
+            s = s .. " "
+        end
+        return s
+    end
+    return self.content[y]
 end
 
 function grid:join_vert(g, align_left)
-	local w = math.max(self.w, g.w)
-	local h = self.h+g.h
-	local combined = {}
+    local w = math.max(self.w, g.w)
+    local h = self.h + g.h
+    local combined = {}
 
-	local s1, s2
-	if not align_left then
-		s1 = math.floor((w-self.w)/2)
-		s2 = math.floor((w-g.w)/2)
-	else
-		s1 = 0
-		s2 = 0
-	end
+    local s1, s2
+    if not align_left then
+        s1 = math.floor((w - self.w) / 2)
+        s2 = math.floor((w - g.w) / 2)
+    else
+        s1 = 0
+        s2 = 0
+    end
 
-	for x=1,w do
-		local c1 = self:get_col(x-s1)
-		local c2 = g:get_col(x-s2)
+    for x = 1, w do
+        local c1 = self:get_col(x - s1)
+        local c2 = g:get_col(x - s2)
 
-		table.insert(combined, c1 .. c2)
+        table.insert(combined, c1 .. c2)
+    end
 
-	end
+    local rows = {}
+    for y = 1, h do
+        local row = ""
+        for x = 1, w do
+            row = row .. utf8char(combined[x], y - 1)
+        end
+        table.insert(rows, row)
+    end
 
-	local rows = {}
-	for y=1,h do
-		local row = ""
-		for x=1,w do
-			row = row .. utf8char(combined[x], y-1)
-		end
-		table.insert(rows, row)
-	end
+    local c = grid:new(w, h, rows)
+    table.insert(c.children, { self, s1, 0 })
+    table.insert(c.children, { g, s2, self.h })
 
-	local c = grid:new(w, h, rows)
-  table.insert(c.children, { self, s1, 0 })
-  table.insert(c.children, { g, s2, self.h })
-
-  return c
+    return c
 end
 
-function grid:get_col(x) 
-	local s = ""
-	if x < 1 or x > self.w then
-		for i=1,self.h do s = s .. " " end
-	else
-		for y=1,self.h do
-			s = s .. utf8char(self.content[y], x-1)
-		end
-	end
-	return s
+function grid:get_col(x)
+    local s = ""
+    if x < 1 or x > self.w then
+        for i = 1, self.h do
+            s = s .. " "
+        end
+    else
+        for y = 1, self.h do
+            s = s .. utf8char(self.content[y], x - 1)
+        end
+    end
+    return s
 end
 
 function grid:enclose_paren()
-	local left_content = {}
-	if self.h == 1 then
-		left_content = { style.left_single_par }
-	else
-		for y=1,self.h do
-			if y == 1 then table.insert(left_content, style.left_top_par)
-			elseif y == self.h then table.insert(left_content, style.left_bottom_par)
-			else table.insert(left_content, style.left_middle_par)
-			end
-		end
-	end
+    local left_content = {}
+    if self.h == 1 then
+        left_content = { style.left_single_par }
+    else
+        for y = 1, self.h do
+            if y == 1 then
+                table.insert(left_content, style.left_top_par)
+            elseif y == self.h then
+                table.insert(left_content, style.left_bottom_par)
+            else
+                table.insert(left_content, style.left_middle_par)
+            end
+        end
+    end
 
-	local left_paren = grid:new(1, self.h, left_content, "par")
-	left_paren.my = self.my
+    local left_paren = grid:new(1, self.h, left_content, "par")
+    left_paren.my = self.my
 
-	local right_content = {}
-	if self.h == 1 then
-		right_content = { style.right_single_par }
-	else
-		for y=1,self.h do
-			if y == 1 then table.insert(right_content, style.right_top_par)
-			elseif y == self.h then table.insert(right_content, style.right_bottom_par)
-			else table.insert(right_content, style.right_middle_par)
-			end
-		end
-	end
+    local right_content = {}
+    if self.h == 1 then
+        right_content = { style.right_single_par }
+    else
+        for y = 1, self.h do
+            if y == 1 then
+                table.insert(right_content, style.right_top_par)
+            elseif y == self.h then
+                table.insert(right_content, style.right_bottom_par)
+            else
+                table.insert(right_content, style.right_middle_par)
+            end
+        end
+    end
 
-	local right_paren = grid:new(1, self.h, right_content, "par")
-	right_paren.my = self.my
+    local right_paren = grid:new(1, self.h, right_content, "par")
+    right_paren.my = self.my
 
-
-	local c1 = left_paren:join_hori(self)
-	local c2 = c1:join_hori(right_paren)
-	return c2
+    local c1 = left_paren:join_hori(self)
+    local c2 = c1:join_hori(right_paren)
+    return c2
 end
 
 function grid:put_paren(exp, parent)
-	if exp.priority() < parent.priority() then
-		return self:enclose_paren()
-	else
-		return self
-	end
+    if exp.priority() < parent.priority() then
+        return self:enclose_paren()
+    else
+        return self
+    end
 end
 
 function grid:join_super(superscript)
-	local spacer = grid:new(self.w, superscript.h)
+    local spacer = grid:new(self.w, superscript.h)
 
-
-	local upper = spacer:join_hori(superscript, true)
-	local result = upper:join_vert(self, true)
-	result.my = self.my + superscript.h
-	return result
+    local upper = spacer:join_hori(superscript, true)
+    local result = upper:join_vert(self, true)
+    result.my = self.my + superscript.h
+    return result
 end
 
 function grid:combine_sub(other)
-	local spacer = grid:new(self.w, other.h)
+    local spacer = grid:new(self.w, other.h)
 
-
-
-
-	local lower = spacer:join_hori(other)
-	local result = self:join_vert(lower, true)
-	result.my = self.my
-	return result
+    local lower = spacer:join_hori(other)
+    local result = self:join_vert(lower, true)
+    result.my = self.my
+    return result
 end
 
 function grid:join_sub_sup(sub, sup)
-	local upper_spacer = grid:new(self.w, sup.h)
-	local middle_spacer = grid:new(math.max(sub.w, sup.w), self.h)
+    local upper_spacer = grid:new(self.w, sup.h)
+    local middle_spacer = grid:new(math.max(sub.w, sup.w), self.h)
 
-	local right = sup:join_vert(middle_spacer, true)
-	right = right:join_vert(sub, true)
+    local right = sup:join_vert(middle_spacer, true)
+    right = right:join_vert(sub, true)
 
-	local left = upper_spacer:join_vert(self, true)
-	local res = left:join_hori(right, true)
-	res.my = self.my + sup.h
-	return res
+    local left = upper_spacer:join_vert(self, true)
+    local res = left:join_hori(right, true)
+    res.my = self.my + sup.h
+    return res
 end
 
 function grid:enclose_bracket()
-	local left_content = {}
-	if self.h == 1 then
-		left_content = { style.left_single_bra }
-	elseif self.h == 2 then
-		left_content = { ' ', style.left_single_bra }
-	else
-		for y=1,self.h do
-			if y == 1 then table.insert(left_content, style.left_top_bra)
-			elseif y == self.h then table.insert(left_content, style.left_bottom_bra)
-			elseif y == math.ceil(self.h/2) then table.insert(left_content, style.left_middle_bra)
-	    else
-	      table.insert(left_content, style.left_other_bra)
-			end
-		end
-	end
+    local left_content = {}
+    if self.h == 1 then
+        left_content = { style.left_single_bra }
+    elseif self.h == 2 then
+        left_content = { " ", style.left_single_bra }
+    else
+        for y = 1, self.h do
+            if y == 1 then
+                table.insert(left_content, style.left_top_bra)
+            elseif y == self.h then
+                table.insert(left_content, style.left_bottom_bra)
+            elseif y == math.ceil(self.h / 2) then
+                table.insert(left_content, style.left_middle_bra)
+            else
+                table.insert(left_content, style.left_other_bra)
+            end
+        end
+    end
 
-	local left_bra = grid:new(1, self.h, left_content, "bra")
-	left_bra.my = self.my
+    local left_bra = grid:new(1, self.h, left_content, "bra")
+    left_bra.my = self.my
 
-	local right_content = {}
-	if self.h == 1 then
-		right_content = { style.right_single_bra }
-	elseif self.h == 2 then
-		right_content = { ' ', style.right_single_bra }
-	else
-		for y=1,self.h do
-			if y == 1 then table.insert(right_content, style.right_top_bra)
-			elseif y == self.h then table.insert(right_content, style.right_bottom_bra)
-			elseif y == math.ceil(self.h/2) then table.insert(right_content, style.right_middle_bra)
-	    else
-	      table.insert(right_content, style.right_other_bra)
-			end
-		end
-	end
+    local right_content = {}
+    if self.h == 1 then
+        right_content = { style.right_single_bra }
+    elseif self.h == 2 then
+        right_content = { " ", style.right_single_bra }
+    else
+        for y = 1, self.h do
+            if y == 1 then
+                table.insert(right_content, style.right_top_bra)
+            elseif y == self.h then
+                table.insert(right_content, style.right_bottom_bra)
+            elseif y == math.ceil(self.h / 2) then
+                table.insert(right_content, style.right_middle_bra)
+            else
+                table.insert(right_content, style.right_other_bra)
+            end
+        end
+    end
 
-	local right_bra = grid:new(1, self.h, right_content, "bra")
-	right_bra.my = self.my
+    local right_bra = grid:new(1, self.h, right_content, "bra")
+    right_bra.my = self.my
 
-
-	local c1 = left_bra:join_hori(self)
-	local c2 = c1:join_hori(right_bra)
-	return c2
+    local c1 = left_bra:join_hori(self)
+    local c2 = c1:join_hori(right_bra)
+    return c2
 end
 
-
-
-local sub_letters = { 
-	["+"] = "₊", ["-"] = "₋", ["="] = "₌", ["("] = "₍", [")"] = "₎",
-	["a"] = "ₐ", ["e"] = "ₑ", ["o"] = "ₒ", ["x"] = "ₓ", ["ə"] = "ₔ", ["h"] = "ₕ", ["k"] = "ₖ", ["l"] = "ₗ", ["m"] = "ₘ", ["n"] = "ₙ", ["p"] = "ₚ", ["s"] = "ₛ", ["t"] = "ₜ", ["i"] = "ᵢ", ["j"] = "ⱼ", ["r"] = "ᵣ", ["u"] = "ᵤ", ["v"] = "ᵥ",
-	["0"] = "₀", ["1"] = "₁", ["2"] = "₂", ["3"] = "₃", ["4"] = "₄", ["5"] = "₅", ["6"] = "₆", ["7"] = "₇", ["8"] = "₈", ["9"] = "₉",
+local sub_letters = {
+    ["+"] = "₊",
+    ["-"] = "₋",
+    ["="] = "₌",
+    ["("] = "₍",
+    [")"] = "₎",
+    ["a"] = "ₐ",
+    ["e"] = "ₑ",
+    ["o"] = "ₒ",
+    ["x"] = "ₓ",
+    ["ə"] = "ₔ",
+    ["h"] = "ₕ",
+    ["k"] = "ₖ",
+    ["l"] = "ₗ",
+    ["m"] = "ₘ",
+    ["n"] = "ₙ",
+    ["p"] = "ₚ",
+    ["s"] = "ₛ",
+    ["t"] = "ₜ",
+    ["i"] = "ᵢ",
+    ["j"] = "ⱼ",
+    ["r"] = "ᵣ",
+    ["u"] = "ᵤ",
+    ["v"] = "ᵥ",
+    ["0"] = "₀",
+    ["1"] = "₁",
+    ["2"] = "₂",
+    ["3"] = "₃",
+    ["4"] = "₄",
+    ["5"] = "₅",
+    ["6"] = "₆",
+    ["7"] = "₇",
+    ["8"] = "₈",
+    ["9"] = "₉",
 }
 
 local frac_set = {
-	[0] = { [3] = "↉" },
-	[1] = { [2] = "½", [3] = "⅓", [4] = "¼", [5] = "⅕", [6] = "⅙", [7] = "⅐", [8] = "⅛", [9] = "⅑", [10] = "⅒" },
-	[2] = { [3] = "⅔", [4] = "¾", [5] = "⅖" },
-	[3] = { [5] = "⅗", [8] = "⅜" },
-	[4] = { [5] = "⅘" },
-	[5] = { [6] = "⅚", [8] = "⅝" },
-	[7] = { [8] = "⅞" },
+    [0] = { [3] = "↉" },
+    [1] = {
+        [2] = "½",
+        [3] = "⅓",
+        [4] = "¼",
+        [5] = "⅕",
+        [6] = "⅙",
+        [7] = "⅐",
+        [8] = "⅛",
+        [9] = "⅑",
+        [10] = "⅒",
+    },
+    [2] = { [3] = "⅔", [4] = "¾", [5] = "⅖" },
+    [3] = { [5] = "⅗", [8] = "⅜" },
+    [4] = { [5] = "⅘" },
+    [5] = { [6] = "⅚", [8] = "⅝" },
+    [7] = { [8] = "⅞" },
 }
 
-local sup_letters = { 
-	["+"] = "⁺", ["-"] = "⁻", ["="] = "⁼", ["("] = "⁽", [")"] = "⁾",
-	["n"] = "ⁿ",
-	["0"] = "⁰", ["1"] = "¹", ["2"] = "²", ["3"] = "³", ["4"] = "⁴", ["5"] = "⁵", ["6"] = "⁶", ["7"] = "⁷", ["8"] = "⁸", ["9"] = "⁹",
-	["i"] = "ⁱ", ["j"] = "ʲ", ["w"] = "ʷ",
-  ["T"] = "ᵀ", ["A"] = "ᴬ", ["B"] = "ᴮ", ["D"] = "ᴰ", ["E"] = "ᴱ", ["G"] = "ᴳ", ["H"] = "ᴴ", ["I"] = "ᴵ", ["J"] = "ᴶ", ["K"] = "ᴷ", ["L"] = "ᴸ", ["M"] = "ᴹ", ["N"] = "ᴺ", ["O"] = "ᴼ", ["P"] = "ᴾ", ["R"] = "ᴿ", ["U"] = "ᵁ", ["V"] = "ⱽ", ["W"] = "ᵂ",
+local sup_letters = {
+    ["+"] = "⁺",
+    ["-"] = "⁻",
+    ["="] = "⁼",
+    ["("] = "⁽",
+    [")"] = "⁾",
+    ["n"] = "ⁿ",
+    ["0"] = "⁰",
+    ["1"] = "¹",
+    ["2"] = "²",
+    ["3"] = "³",
+    ["4"] = "⁴",
+    ["5"] = "⁵",
+    ["6"] = "⁶",
+    ["7"] = "⁷",
+    ["8"] = "⁸",
+    ["9"] = "⁹",
+    ["i"] = "ⁱ",
+    ["j"] = "ʲ",
+    ["w"] = "ʷ",
+    ["T"] = "ᵀ",
+    ["A"] = "ᴬ",
+    ["B"] = "ᴮ",
+    ["D"] = "ᴰ",
+    ["E"] = "ᴱ",
+    ["G"] = "ᴳ",
+    ["H"] = "ᴴ",
+    ["I"] = "ᴵ",
+    ["J"] = "ᴶ",
+    ["K"] = "ᴷ",
+    ["L"] = "ᴸ",
+    ["M"] = "ᴹ",
+    ["N"] = "ᴺ",
+    ["O"] = "ᴼ",
+    ["P"] = "ᴾ",
+    ["R"] = "ᴿ",
+    ["U"] = "ᵁ",
+    ["V"] = "ⱽ",
+    ["W"] = "ᵂ",
 }
 
 local mathbb = {
-  ["0"] = "𝟘",
-  ["1"] = "𝟙",
-  ["2"] = "𝟚",
-  ["3"] = "𝟛",
-  ["4"] = "𝟜",
-  ["5"] = "𝟝",
-  ["6"] = "𝟞",
-  ["7"] = "𝟟",
-  ["8"] = "𝟠",
-  ["9"] = "𝟡",
-  ["R"] = "ℝ",
-  ["N"] = "ℕ",
-  ["Z"] = "ℤ",
-  ["C"] = "ℂ",
-  ["H"] = "ℍ",
-  ["Q"] = "ℚ",
+    ["0"] = "𝟘",
+    ["1"] = "𝟙",
+    ["2"] = "𝟚",
+    ["3"] = "𝟛",
+    ["4"] = "𝟜",
+    ["5"] = "𝟝",
+    ["6"] = "𝟞",
+    ["7"] = "𝟟",
+    ["8"] = "𝟠",
+    ["9"] = "𝟡",
+    ["R"] = "ℝ",
+    ["N"] = "ℕ",
+    ["Z"] = "ℤ",
+    ["C"] = "ℂ",
+    ["H"] = "ℍ",
+    ["Q"] = "ℚ",
 }
 
 local mathcal = {
-  ["A"] = "𝒜",
-  ["B"] = "ℬ",
-  ["C"] = "𝒞",
-  ["D"] = "𝒟",
-  ["E"] = "ℰ",
-  ["F"] = "ℱ",
-  ["G"] = "𝒢",
-  ["H"] = "ℋ",
-  ["I"] = "ℐ",
-  ["J"] = "𝒥",
-  ["K"] = "𝒦",
-  ["L"] = "ℒ",
-  ["M"] = "ℳ",
-  ["N"] = "𝒩",
-  ["O"] = "𝒪",
-  ["P"] = "𝒫",
-  ["Q"] = "𝒬",
-  ["R"] = "ℛ",
-  ["S"] = "𝒮",
-  ["T"] = "𝒯",
-  ["U"] = "𝒰",
-  ["V"] = "𝒱",
-  ["W"] = "𝒲",
-  ["X"] = "𝒳",
-  ["Y"] = "𝒴",
-  ["Z"] = "𝒵",
+    ["A"] = "𝒜",
+    ["B"] = "ℬ",
+    ["C"] = "𝒞",
+    ["D"] = "𝒟",
+    ["E"] = "ℰ",
+    ["F"] = "ℱ",
+    ["G"] = "𝒢",
+    ["H"] = "ℋ",
+    ["I"] = "ℐ",
+    ["J"] = "𝒥",
+    ["K"] = "𝒦",
+    ["L"] = "ℒ",
+    ["M"] = "ℳ",
+    ["N"] = "𝒩",
+    ["O"] = "𝒪",
+    ["P"] = "𝒫",
+    ["Q"] = "𝒬",
+    ["R"] = "ℛ",
+    ["S"] = "𝒮",
+    ["T"] = "𝒯",
+    ["U"] = "𝒰",
+    ["V"] = "𝒱",
+    ["W"] = "𝒲",
+    ["X"] = "𝒳",
+    ["Y"] = "𝒴",
+    ["Z"] = "𝒵",
 }
 
 local plain_functions = {
-	["min"] = true,
-	["lim"] = true,
-	["exp"] = true,
-	["log"] = true,
+    ["min"] = true,
+    ["lim"] = true,
+    ["exp"] = true,
+    ["log"] = true,
 }
 
 function combine_brackets(res)
-  local left_content, right_content = {}, {}
-  if res.h > 1 then
-    for y=1,res.h do
-      if y == 1 then
-        table.insert(left_content, style.matrix_upper_left)
-        table.insert(right_content, style.matrix_upper_right)
-      elseif y == res.h then
-        table.insert(left_content, style.matrix_lower_left)
-        table.insert(right_content, style.matrix_lower_right)
-      else
-        table.insert(left_content, style.matrix_vert_left)
-        table.insert(right_content, style.matrix_vert_right)
-      end
+    local left_content, right_content = {}, {}
+    if res.h > 1 then
+        for y = 1, res.h do
+            if y == 1 then
+                table.insert(left_content, style.matrix_upper_left)
+                table.insert(right_content, style.matrix_upper_right)
+            elseif y == res.h then
+                table.insert(left_content, style.matrix_lower_left)
+                table.insert(right_content, style.matrix_lower_right)
+            else
+                table.insert(left_content, style.matrix_vert_left)
+                table.insert(right_content, style.matrix_vert_right)
+            end
+        end
+    else
+        left_content = { style.matrix_single_left }
+        right_content = { style.matrix_single_right }
     end
-  else
-    left_content = { style.matrix_single_left }
-    right_content = { style.matrix_single_right }
-  end
 
-  local leftbracket = grid:new(1, res.h, left_content)
-  local rightbracket = grid:new(1, res.h, right_content)
+    local leftbracket = grid:new(1, res.h, left_content)
+    local rightbracket = grid:new(1, res.h, right_content)
 
-  res = leftbracket:join_hori(res, true)
-  res = res:join_hori(rightbracket, true)
-  return res
+    res = leftbracket:join_hori(res, true)
+    res = res:join_hori(rightbracket, true)
+    return res
 end
 
 function stack_subsup(explist, i, g)
-  i = i + 1
-  while i <= #explist do
-    local exp = explist[i]
-    if exp.kind == "subexp" then
-      i = i + 1
-    	local my = g.my
-    	local subgrid = to_ascii({explist[i]}, 1)
-    	g = g:join_vert(subgrid)
-    	g.my = my
-      i = i + 1
-
-    elseif exp.kind == "supexp" then
-      i = i + 1
-    	local my = g.my
-    	local supgrid = to_ascii({explist[i]}, 1)
-    	g = supgrid:join_vert(g)
-    	g.my = my + supgrid.h
-      i = i + 1
-
-    else 
-      break
+    i = i + 1
+    while i <= #explist do
+        local exp = explist[i]
+        if exp.kind == "subexp" then
+            i = i + 1
+            local my = g.my
+            local subgrid = to_ascii({ explist[i] }, 1)
+            g = g:join_vert(subgrid)
+            g.my = my
+            i = i + 1
+        elseif exp.kind == "supexp" then
+            i = i + 1
+            local my = g.my
+            local supgrid = to_ascii({ explist[i] }, 1)
+            g = supgrid:join_vert(g)
+            g.my = my + supgrid.h
+            i = i + 1
+        else
+            break
+        end
     end
-
-  end
-  i = i - 1
-  return g, i
+    i = i - 1
+    return g, i
 end
 
 function grid_of_exps(explist)
-  local cellsgrid = {}
-  local maxheight = 0
-  local i = 1
-  local rowgrid = {}
-  while i <= #explist do
-  	local cell_list = {
-  		kind = "explist",
-  		exps = {},
-  	}
+    local cellsgrid = {}
+    local maxheight = 0
+    local i = 1
+    local rowgrid = {}
+    while i <= #explist do
+        local cell_list = {
+            kind = "explist",
+            exps = {},
+        }
 
-  	while i <= #explist do
-  		if explist[i].kind == "symexp" and explist[i].sym == "&" then
-  			local cellgrid = to_ascii({cell_list}, 1)
-  			table.insert(rowgrid, cellgrid)
-  			maxheight = math.max(maxheight, cellgrid.h)
-  			i = i+1
-  			break
+        while i <= #explist do
+            if explist[i].kind == "symexp" and explist[i].sym == "&" then
+                local cellgrid = to_ascii({ cell_list }, 1)
+                table.insert(rowgrid, cellgrid)
+                maxheight = math.max(maxheight, cellgrid.h)
+                i = i + 1
+                break
+            elseif explist[i].kind == "funexp" and explist[i].sym == "\\" then
+                local cellgrid = to_ascii({ cell_list }, 1)
+                table.insert(rowgrid, cellgrid)
+                maxheight = math.max(maxheight, cellgrid.h)
 
-  		elseif explist[i].kind == "funexp" and explist[i].sym == "\\" then
-  			local cellgrid = to_ascii({cell_list}, 1)
-  			table.insert(rowgrid, cellgrid)
-  			maxheight = math.max(maxheight, cellgrid.h)
+                table.insert(cellsgrid, rowgrid)
+                rowgrid = {}
+                i = i + 1
+                break
+            else
+                table.insert(cell_list.exps, explist[i])
+                i = i + 1
+            end
 
-  			table.insert(cellsgrid, rowgrid)
-  			rowgrid = {}
-  			i = i+1
-  			break
+            if i > #explist then
+                local cellgrid = to_ascii({ cell_list }, 1)
+                table.insert(rowgrid, cellgrid)
+                maxheight = math.max(maxheight, cellgrid.h)
 
-  		else
-  			table.insert(cell_list.exps, explist[i])
-  			i = i+1
-  		end
+                table.insert(cellsgrid, rowgrid)
+            end
+        end
+    end
 
-  		if i > #explist then
-  			local cellgrid = to_ascii({cell_list}, 1)
-  			table.insert(rowgrid, cellgrid)
-  			maxheight = math.max(maxheight, cellgrid.h)
-
-  			table.insert(cellsgrid, rowgrid)
-  		end
-
-  	end
-
-  end
-
-  return cellsgrid, maxheight
+    return cellsgrid, maxheight
 end
 
 function combine_matrix_grid(cellsgrid, maxheight)
-  local res
-  local row_heights = {}
-  local baselines = {}
+    local res
+    local row_heights = {}
+    local baselines = {}
 
-  for i=1,#cellsgrid do
-    local height_below = 0
-    local height_above = 0
-    local baseline = 0
-    for j=1,#cellsgrid[i] do
-      local cell = cellsgrid[i][j]
-      height_below = math.max(cell.my, height_below)
-      height_above = math.max(cell.h - cell.my - 1, height_above)
-      baseline = math.max(baseline, cell.my)
+    for i = 1, #cellsgrid do
+        local height_below = 0
+        local height_above = 0
+        local baseline = 0
+        for j = 1, #cellsgrid[i] do
+            local cell = cellsgrid[i][j]
+            height_below = math.max(cell.my, height_below)
+            height_above = math.max(cell.h - cell.my - 1, height_above)
+            baseline = math.max(baseline, cell.my)
+        end
+        row_heights[i] = height_below + height_above + 1
+        baselines[i] = baseline
     end
-    row_heights[i] = height_below + height_above + 1
-    baselines[i] = baseline
 
-  end
+    for i = 1, #cellsgrid[1] do
+        local col
+        for j = 1, #cellsgrid do
+            local cell = cellsgrid[j][i]
+            local sup = baselines[j] - cell.my
+            local sdown = row_heights[j] - cell.h - sup
+            local up, down
+            if sup > 0 then up = grid:new(cell.w, sup) end
+            if sdown > 0 then down = grid:new(cell.w, sdown) end
 
-  for i=1,#cellsgrid[1] do
-    local col 
-    for j=1,#cellsgrid do
-      local cell = cellsgrid[j][i]
-      local sup = baselines[j] - cell.my
-      local sdown = row_heights[j] - cell.h - sup
-      local up, down
-      if sup > 0 then up = grid:new(cell.w, sup) end
-      if sdown > 0 then down = grid:new(cell.w, sdown) end
+            if up then cell = up:join_vert(cell) end
+            if down then cell = cell:join_vert(down) end
 
-      if up then cell = up:join_vert(cell) end
-      if down then cell = cell:join_vert(down) end
+            local colspacer = grid:new(1, cell.h)
+            colspacer.my = cell.my
 
-      local colspacer = grid:new(1, cell.h)
-      colspacer.my = cell.my
+            if i < #cellsgrid[1] then cell = cell:join_hori(colspacer) end
 
-      if i < #cellsgrid[1] then
-      	cell = cell:join_hori(colspacer)
-      end
-
-      if not col then col = cell
-      else col = col:join_vert(cell, true) end
-
+            if not col then
+                col = cell
+            else
+                col = col:join_vert(cell, true)
+            end
+        end
+        if not res then
+            res = col
+        else
+            res = res:join_hori(col, true)
+        end
     end
-    if not res then res = col
-    else res = res:join_hori(col, true) end
-
-  end
-  return res
+    return res
 end
 
 function unpack_explist(exp)
-  while exp.kind == "explist" do
-    assert(#exp.exps == 1, "explist must be length 1")
-    exp = exp.exps[1]
-  end
-  return exp
+    while exp.kind == "explist" do
+        assert(#exp.exps == 1, "explist must be length 1")
+        exp = exp.exps[1]
+    end
+    return exp
 end
 
 function put_subsup_aside(g, sub, sup)
-  if sub and sup then 
-  	local subscript = ""
-    -- sub and sup are exchanged to
-    -- make the most compact expression
-  	local subexps = sup.exps
-    local sub_t
-  	if #subexps == 1 and subexps[1].kind == "numexp" or (subexps[1].kind == "symexp" and string.match(subexps[1].sym, "^%d+$")) then
-  	  sub_t = "num"
-  	elseif subexps[1].kind == "symexp" and string.match(subexps[1].sym, "^%a+$") then
-  	  sub_t = "var"
-  	else
-  	  sub_t = "sym"
-  	end
+    if sub and sup then
+        local subscript = ""
+        -- sub and sup are exchanged to
+        -- make the most compact expression
+        local subexps = sup.exps
+        local sub_t
+        if
+            #subexps == 1 and subexps[1].kind == "numexp"
+            or (subexps[1].kind == "symexp" and string.match(subexps[1].sym, "^%d+$"))
+        then
+            sub_t = "num"
+        elseif subexps[1].kind == "symexp" and string.match(subexps[1].sym, "^%a+$") then
+            sub_t = "var"
+        else
+            sub_t = "sym"
+        end
 
-  	for _, exp in ipairs(subexps) do
-  		if exp.kind == "numexp" and math.floor(exp.num) == exp.num then
-  			local num = exp.num
-  			if num == 0 then
-  				subscript = subscript .. sub_letters["0"]
-  			else
-  				if num < 0 then
-  					subscript = "₋" .. subscript
-  					num = math.abs(num)
-  				end
-  				local num_subscript = ""
-  				while num ~= 0 do
-  					num_subscript = sub_letters[tostring(num%10)] .. num_subscript 
-  					num = math.floor(num / 10)
-  				end
-  				subscript = subscript .. num_subscript 
-  			end
+        for _, exp in ipairs(subexps) do
+            if exp.kind == "numexp" and math.floor(exp.num) == exp.num then
+                local num = exp.num
+                if num == 0 then
+                    subscript = subscript .. sub_letters["0"]
+                else
+                    if num < 0 then
+                        subscript = "₋" .. subscript
+                        num = math.abs(num)
+                    end
+                    local num_subscript = ""
+                    while num ~= 0 do
+                        num_subscript = sub_letters[tostring(num % 10)] .. num_subscript
+                        num = math.floor(num / 10)
+                    end
+                    subscript = subscript .. num_subscript
+                end
+            elseif exp.kind == "symexp" then
+                if sub_letters[exp.sym] and not exp.sub and not exp.sup then
+                    subscript = subscript .. sub_letters[exp.sym]
+                else
+                    subscript = nil
+                    break
+                end
+            else
+                subscript = nil
+                break
+            end
+        end
 
-  		elseif exp.kind == "symexp" then
-  			if sub_letters[exp.sym] and not exp.sub and not exp.sup then
-  				subscript = subscript .. sub_letters[exp.sym]
-  			else
-  				subscript = nil
-  				break
-  			end
+        local superscript = ""
+        local supexps = sub.exps
+        local sup_t
+        if
+            #supexps == 1 and supexps[1].kind == "numexp"
+            or (supexps[1].kind == "symexp" and string.match(supexps[1].sym, "^%d+$"))
+        then
+            sup_t = "num"
+        elseif supexps[1].kind == "symexp" and string.match(supexps[1].sym, "^%a+$") then
+            sup_t = "var"
+        else
+            sup_t = "sym"
+        end
 
-  		else
-  			subscript = nil
-  			break
-  		end
-  	end
+        for _, exp in ipairs(supexps) do
+            if exp.kind == "numexp" and math.floor(exp.num) == exp.num then
+                local num = exp.num
+                if num == 0 then
+                    superscript = superscript .. sub_letters["0"]
+                else
+                    if num < 0 then
+                        superscript = "₋" .. superscript
+                        num = math.abs(num)
+                    end
+                    local num_superscript = ""
+                    while num ~= 0 do
+                        num_superscript = sup_letters[tostring(num % 10)] .. num_superscript
+                        num = math.floor(num / 10)
+                    end
+                    superscript = superscript .. num_superscript
+                end
+            elseif exp.kind == "symexp" then
+                if sup_letters[exp.sym] and not exp.sub and not exp.sup then
+                    superscript = superscript .. sup_letters[exp.sym]
+                else
+                    superscript = nil
+                    break
+                end
+            else
+                superscript = nil
+                break
+            end
+        end
 
+        if subscript and superscript then
+            local sup_g = grid:new(utf8len(subscript), 1, { subscript }, sub_t)
+            local sub_g = grid:new(utf8len(superscript), 1, { superscript }, sup_t)
+            g = g:join_sub_sup(sub_g, sup_g)
+        else
+            local subgrid = to_ascii({ sub }, 1)
+            local supgrid = to_ascii({ sup }, 1)
+            g = g:join_sub_sup(subgrid, supgrid)
+        end
+    end
 
-  	local superscript = ""
-  	local supexps = sub.exps
-    local sup_t
-  	if #supexps == 1 and supexps[1].kind == "numexp" or (supexps[1].kind == "symexp" and string.match(supexps[1].sym, "^%d+$")) then
-  	  sup_t = "num"
-  	elseif supexps[1].kind == "symexp" and string.match(supexps[1].sym, "^%a+$") then
-  	  sup_t = "var"
-  	else
-  	  sup_t = "sym"
-  	end
-
-  	for _, exp in ipairs(supexps) do
-  		if exp.kind == "numexp" and math.floor(exp.num) == exp.num then
-  			local num = exp.num
-  			if num == 0 then
-  				superscript = superscript .. sub_letters["0"]
-  			else
-  				if num < 0 then
-  					superscript = "₋" .. superscript
-  					num = math.abs(num)
-  				end
-  				local num_superscript = ""
-  				while num ~= 0 do
-  					num_superscript = sup_letters[tostring(num%10)] .. num_superscript 
-  					num = math.floor(num / 10)
-  				end
-  				superscript = superscript .. num_superscript 
-  			end
-
-  		elseif exp.kind == "symexp" then
-  			if sup_letters[exp.sym] and not exp.sub and not exp.sup then
-  				superscript = superscript .. sup_letters[exp.sym]
-  			else
-  				superscript = nil
-  				break
-  			end
-
-  		else
-  			superscript = nil
-  			break
-  		end
-  	end
-
-
-  	if subscript and superscript then
-  		local sup_g = grid:new(utf8len(subscript), 1, { subscript }, sub_t)
-  		local sub_g = grid:new(utf8len(superscript), 1, { superscript }, sup_t)
-  		g = g:join_sub_sup(sub_g, sup_g)
-  	else
-  		local subgrid = to_ascii({sub}, 1)
-  		local supgrid = to_ascii({sup}, 1)
-  		g = g:join_sub_sup(subgrid, supgrid)
-  	end
-
-  end
-
-  return g
+    return g
 end
 
 function put_if_only_sub(g, sub, sup)
-  if sub and not sup then 
-  	local subscript = ""
-  	local subexps = sub.exps
-    local sub_t
-  	if #subexps == 1 and subexps[1].kind == "numexp" or (subexps[1].kind == "symexp" and string.match(subexps[1].sym, "^%d+$")) then
-  	  sub_t = "num"
-  	elseif subexps[1].kind == "symexp" and string.match(subexps[1].sym, "^%a+$") then
-  	  sub_t = "var"
-  	else
-  	  sub_t = "sym"
-  	end
+    if sub and not sup then
+        local subscript = ""
+        local subexps = sub.exps
+        local sub_t
+        if
+            #subexps == 1 and subexps[1].kind == "numexp"
+            or (subexps[1].kind == "symexp" and string.match(subexps[1].sym, "^%d+$"))
+        then
+            sub_t = "num"
+        elseif subexps[1].kind == "symexp" and string.match(subexps[1].sym, "^%a+$") then
+            sub_t = "var"
+        else
+            sub_t = "sym"
+        end
 
-  	for _, exp in ipairs(subexps) do
-  		if exp.kind == "numexp" and math.floor(exp.num) == exp.num then
-  			local num = exp.num
-  			if num == 0 then
-  				subscript = subscript .. sub_letters["0"]
-  			else
-  				if num < 0 then
-  					subscript = "₋" .. subscript
-  					num = math.abs(num)
-  				end
-  				local num_subscript = ""
-  				while num ~= 0 do
-  					num_subscript = sub_letters[tostring(num%10)] .. num_subscript 
-  					num = math.floor(num / 10)
-  				end
-  				subscript = subscript .. num_subscript 
-  			end
+        for _, exp in ipairs(subexps) do
+            if exp.kind == "numexp" and math.floor(exp.num) == exp.num then
+                local num = exp.num
+                if num == 0 then
+                    subscript = subscript .. sub_letters["0"]
+                else
+                    if num < 0 then
+                        subscript = "₋" .. subscript
+                        num = math.abs(num)
+                    end
+                    local num_subscript = ""
+                    while num ~= 0 do
+                        num_subscript = sub_letters[tostring(num % 10)] .. num_subscript
+                        num = math.floor(num / 10)
+                    end
+                    subscript = subscript .. num_subscript
+                end
+            elseif exp.kind == "symexp" then
+                if sub_letters[exp.sym] and not exp.sub and not exp.sup then
+                    subscript = subscript .. sub_letters[exp.sym]
+                else
+                    subscript = nil
+                    break
+                end
+            else
+                subscript = nil
+                break
+            end
+        end
 
-  		elseif exp.kind == "symexp" then
-  			if sub_letters[exp.sym] and not exp.sub and not exp.sup then
-  				subscript = subscript .. sub_letters[exp.sym]
-  			else
-  				subscript = nil
-  				break
-  			end
+        if subscript and string.len(subscript) > 0 then
+            local sub_g = grid:new(utf8len(subscript), 1, { subscript }, sub_t)
+            g = g:join_hori(sub_g)
+        else
+            local subgrid
+            local frac_exps = sub.exps
+            local frac_exp
+            if #frac_exps == 1 then
+                local exp = frac_exps[1]
+                if exp.kind == "funexp" and exp.sym == "frac" then
+                    assert(#exp.args == 2, "frac must have 2 arguments")
+                    local numerator = exp.args[1].exps
+                    local denominator = exp.args[2].exps
+                    if
+                        #numerator == 1
+                        and numerator[1].kind == "numexp"
+                        and #denominator == 1
+                        and denominator[1].kind == "numexp"
+                    then
+                        local A = numerator[1].num
+                        local B = denominator[1].num
+                        if frac_set[A] and frac_set[A][B] then
+                            frac_exp = grid:new(1, 1, { frac_set[A][B] })
+                        else
+                            local num_str = ""
+                            local den_str = ""
+                            if math.floor(A) == A then
+                                local s = tostring(A)
+                                for i = 1, string.len(s) do
+                                    num_str = num_str .. sup_letters[string.sub(s, i, i)]
+                                end
+                            end
 
-  		else
-  			subscript = nil
-  			break
-  		end
-  	end
+                            if math.floor(B) == B then
+                                local s = tostring(B)
+                                for i = 1, string.len(s) do
+                                    den_str = den_str .. sub_letters[string.sub(s, i, i)]
+                                end
+                            end
 
-  	if subscript and string.len(subscript) > 0 then
-  		local sub_g = grid:new(utf8len(subscript), 1, { subscript }, sub_t)
-  		g = g:join_hori(sub_g)
+                            if string.len(num_str) > 0 and string.len(den_str) > 0 then
+                                local frac_str = num_str .. "⁄" .. den_str
+                                frac_exp = grid:new(utf8len(frac_str), 1, { frac_str })
+                            end
+                        end
+                    end
+                end
+            end
 
-  	else
-  		local subgrid
-  		local frac_exps = sub.exps
-  		local frac_exp
-  		if #frac_exps == 1  then
-  			local exp = frac_exps[1]
-  			if exp.kind == "funexp" and exp.sym == "frac" then
-  				assert(#exp.args == 2, "frac must have 2 arguments")
-  				local numerator = exp.args[1].exps
-  				local denominator = exp.args[2].exps
-  				if #numerator == 1 and numerator[1].kind == "numexp" and 
-  					#denominator == 1 and denominator[1].kind == "numexp" then
-  					local A = numerator[1].num
-  					local B = denominator[1].num
-  					if frac_set[A] and frac_set[A][B] then
-  						frac_exp = grid:new(1, 1, { frac_set[A][B] })
-  					else
-  						local num_str = ""
-  						local den_str = ""
-  						if math.floor(A) == A then
-  							local s = tostring(A)
-  							for i=1,string.len(s) do
-  								num_str = num_str .. sup_letters[string.sub(s, i, i)]
-  							end
-  						end
+            if not frac_exp then
+                subgrid = to_ascii({ sub }, 1)
+            else
+                subgrid = frac_exp
+            end
+            g = g:combine_sub(subgrid)
+        end
+    end
 
-  						if math.floor(B) == B then
-  							local s = tostring(B)
-  							for i=1,string.len(s) do
-  								den_str = den_str .. sub_letters[string.sub(s, i, i)]
-  							end
-  						end
-
-  						if string.len(num_str) > 0 and string.len(den_str) > 0 then
-  							local frac_str = num_str .. "⁄" .. den_str
-  							frac_exp = grid:new(utf8len(frac_str), 1, { frac_str })
-  						end
-  					end
-  				end
-
-  			end
-  		end
-
-  		if not frac_exp then
-  			subgrid = to_ascii({sub}, 1)
-  		else
-  			subgrid = frac_exp
-  		end
-  		g = g:combine_sub(subgrid)
-
-  	end
-  end
-
-  return g
+    return g
 end
 
-
 function put_if_only_sup(g, sub, sup)
-  if sup and not sub then 
-  	local superscript = ""
-  	local supexps = sup.exps
-    local sup_t
-  	if #supexps == 1 and supexps[1].kind == "numexp" or (supexps[1].kind == "symexp" and string.match(supexps[1].sym, "^%d+$")) then
-  	  sup_t = "num"
-  	elseif supexps[1].kind == "symexp" and string.match(supexps[1].sym, "^%a+$") then
-  	  sup_t = "var"
-  	else
-  	  sup_t = "sym"
-  	end
+    if sup and not sub then
+        local superscript = ""
+        local supexps = sup.exps
+        local sup_t
+        if
+            #supexps == 1 and supexps[1].kind == "numexp"
+            or (supexps[1].kind == "symexp" and string.match(supexps[1].sym, "^%d+$"))
+        then
+            sup_t = "num"
+        elseif supexps[1].kind == "symexp" and string.match(supexps[1].sym, "^%a+$") then
+            sup_t = "var"
+        else
+            sup_t = "sym"
+        end
 
-  	for _, exp in ipairs(supexps) do
-  		if exp.kind == "numexp" and math.floor(exp.num) == exp.num then
-  			local num = exp.num
-  			if num == 0 then
-  				superscript = superscript .. sub_letters["0"]
-  			else
-  				if num < 0 then
-  					superscript = "₋" .. superscript
-  					num = math.abs(num)
-  				end
-  				local num_superscript = ""
-  				while num ~= 0 do
-  					num_superscript = sup_letters[tostring(num%10)] .. num_superscript 
-  					num = math.floor(num / 10)
-  				end
-  				superscript = superscript .. num_superscript 
-  			end
+        for _, exp in ipairs(supexps) do
+            if exp.kind == "numexp" and math.floor(exp.num) == exp.num then
+                local num = exp.num
+                if num == 0 then
+                    superscript = superscript .. sub_letters["0"]
+                else
+                    if num < 0 then
+                        superscript = "₋" .. superscript
+                        num = math.abs(num)
+                    end
+                    local num_superscript = ""
+                    while num ~= 0 do
+                        num_superscript = sup_letters[tostring(num % 10)] .. num_superscript
+                        num = math.floor(num / 10)
+                    end
+                    superscript = superscript .. num_superscript
+                end
+            elseif exp.kind == "symexp" then
+                if sup_letters[exp.sym] and not exp.sub and not exp.sup then
+                    superscript = superscript .. sup_letters[exp.sym]
+                else
+                    superscript = nil
+                    break
+                end
+            else
+                superscript = nil
+                break
+            end
+        end
 
-  		elseif exp.kind == "symexp" then
-  			if sup_letters[exp.sym] and not exp.sub and not exp.sup then
-  				superscript = superscript .. sup_letters[exp.sym]
-  			else
-  				superscript = nil
-  				break
-  			end
+        if superscript and string.len(superscript) > 0 then
+            local sup_g = grid:new(utf8len(superscript), 1, { superscript }, sup_t)
+            g = g:join_hori(sup_g, true)
+        else
+            local supgrid = to_ascii({ sup }, 1)
+            local frac_exps = sup.exps
+            local frac_exp
+            if #frac_exps == 1 then
+                local exp = frac_exps[1]
+                if exp.kind == "funexp" and exp.sym == "frac" then
+                    assert(#exp.args == 2, "frac must have 2 arguments")
+                    local numerator = exp.args[1].exps
+                    local denominator = exp.args[2].exps
+                    if
+                        #numerator == 1
+                        and numerator[1].kind == "numexp"
+                        and #denominator == 1
+                        and denominator[1].kind == "numexp"
+                    then
+                        local A = numerator[1].num
+                        local B = denominator[1].num
+                        if frac_set[A] and frac_set[A][B] then
+                            frac_exp = grid:new(1, 1, { frac_set[A][B] })
+                        else
+                            local num_str = ""
+                            local den_str = ""
+                            if math.floor(A) == A then
+                                local s = tostring(A)
+                                for i = 1, string.len(s) do
+                                    num_str = num_str .. sup_letters[string.sub(s, i, i)]
+                                end
+                            end
 
-  		else
-  			superscript = nil
-  			break
-  		end
-  	end
+                            if math.floor(B) == B then
+                                local s = tostring(B)
+                                for i = 1, string.len(s) do
+                                    den_str = den_str .. sub_letters[string.sub(s, i, i)]
+                                end
+                            end
 
-  	if superscript and string.len(superscript) > 0 then
-  		local sup_g = grid:new(utf8len(superscript), 1, { superscript }, sup_t)
-  		g = g:join_hori(sup_g, true)
+                            if string.len(num_str) > 0 and string.len(den_str) > 0 then
+                                local frac_str = num_str .. "⁄" .. den_str
+                                frac_exp = grid:new(utf8len(frac_str), 1, { frac_str })
+                            end
+                        end
+                    end
+                end
+            end
 
-  	else
-  		local supgrid = to_ascii({sup}, 1)
-  		local frac_exps = sup.exps
-  		local frac_exp
-  		if #frac_exps == 1  then
-  			local exp = frac_exps[1]
-  			if exp.kind == "funexp" and exp.sym == "frac" then
-  				assert(#exp.args == 2, "frac must have 2 arguments")
-  				local numerator = exp.args[1].exps
-  				local denominator = exp.args[2].exps
-  				if #numerator == 1 and numerator[1].kind == "numexp" and 
-  					#denominator == 1 and denominator[1].kind == "numexp" then
-  					local A = numerator[1].num
-  					local B = denominator[1].num
-  					if frac_set[A] and frac_set[A][B] then
-  						frac_exp = grid:new(1, 1, { frac_set[A][B] })
-  					else
-  						local num_str = ""
-  						local den_str = ""
-  						if math.floor(A) == A then
-  							local s = tostring(A)
-  							for i=1,string.len(s) do
-  								num_str = num_str .. sup_letters[string.sub(s, i, i)]
-  							end
-  						end
+            if not frac_exp then
+                supgrid = to_ascii({ sup }, 1)
+            else
+                supgrid = frac_exp
+            end
+            g = g:join_super(supgrid)
+        end
+    end
 
-  						if math.floor(B) == B then
-  							local s = tostring(B)
-  							for i=1,string.len(s) do
-  								den_str = den_str .. sub_letters[string.sub(s, i, i)]
-  							end
-  						end
-
-  						if string.len(num_str) > 0 and string.len(den_str) > 0 then
-  							local frac_str = num_str .. "⁄" .. den_str
-  							frac_exp = grid:new(utf8len(frac_str), 1, { frac_str })
-  						end
-  					end
-  				end
-
-  			end
-  		end
-
-  		if not frac_exp then
-  			supgrid = to_ascii({sup}, 1)
-  		else
-  			supgrid = frac_exp
-  		end
-  		g = g:join_super(supgrid)
-  	end
-  end
-
-  return g
+    return g
 end
 
 function to_ascii(explist, exp_i)
-  local gs = {}
-  while exp_i <= #explist do
-    local exp = explist[exp_i]
-    local g
-    if exp.kind == "numexp" then
-    	local numstr = tostring(exp.num)
-    	g = grid:new(string.len(numstr), 1, { tostring(numstr) }, "num")
-
-    elseif exp.kind == "symexp" then
-    	local sym =  exp.sym
-    	if not string.match(sym, "^%a") and not string.match(sym, "^%d")  and not string.match(sym, "^%s+$") and sym ~= "/" and sym ~= special_syms["partial"] and sym ~= "[" and sym ~= "]" and sym ~= "'" and sym ~= "|" and sym ~= "." and sym ~= "," and not (exp_i == 1 and sym == "-") and sym ~= special_syms["Vert"] then
-    		sym = " " .. sym .. " "
-    	end
-
-    	g = grid:new(utf8len(sym), 1, { sym }, "sym")
-
-
-    elseif exp.kind == "explist" then
-      g = to_ascii(exp.exps, 1)
-
-    elseif exp.kind == "funexp" then
-    	local name = exp.sym
-    	if name == "frac" then
-    		local leftgrid = to_ascii({explist[exp_i+1]}, 1)
-    		local rightgrid = to_ascii({explist[exp_i+2]}, 1)
-    		exp_i = exp_i + 2
-
-    		local bar = ""
-    		local w = math.max(leftgrid.w, rightgrid.w)
-    		for x=1,w do
-    			bar = bar .. style.div_middle_bar
-    		end
-
-
-    		local opgrid = grid:new(w, 1, { bar })
-
-    		local c1 = leftgrid:join_vert(opgrid)
-    		local c2 = c1:join_vert(rightgrid)
-    		c2.my = leftgrid.h
-
-    		g = c2
-
-
-    	elseif special_syms[name] or special_nums[name] or greek_etc[name] then
-    		local sym = special_syms[name] or special_nums[name] or greek_etc[name]
-    	  local t
-    	  if special_syms[name] then
-    	    t = "sym"
-    	  	if not string.match(sym, "^%a") and not string.match(sym, "^%d")  and not string.match(sym, "^%s+$") and sym ~= "/" and sym ~= special_syms["partial"] and sym ~= "[" and sym ~= "]" and sym ~= "'" and sym ~= "|" and sym ~= "." and sym ~= "," and not (exp_i == 1 and sym == "-") and sym ~= special_syms["Vert"] then
-    	  		sym = " " .. sym .. " "
-    	  	end
-
-    	  elseif special_nums[name] then
-    	    t = "num"
-    	  elseif greek_etc[name] then
-    	    t = "var"
-    	  end
-
-    		g = grid:new(utf8len(sym), 1, { sym }, t)
-
-
-    	elseif name == "sqrt" then
-    		local toroot = to_ascii({explist[exp_i+1]}, 1)
-    	  exp_i = exp_i + 1
-
-    		local left_content = {}
-    		for y=1,toroot.h do 
-    			if y < toroot.h then
-    				table.insert(left_content, " " .. style.root_vert_bar)
-    			else
-    				table.insert(left_content, style.root_bottom .. style.root_vert_bar)
-    			end
-    		end
-
-    		local left_root = grid:new(2, toroot.h, left_content, "sym")
-    		left_root.my = toroot.my
-
-    		local up_str = " " .. style.root_upper_left
-    		for x=1,toroot.w do
-    			up_str = up_str .. style.root_upper
-    		end
-    		up_str = up_str .. style.root_upper_right
-
-    		local top_root = grid:new(toroot.w+2, 1, { up_str }, "sym")
-
-
-    		local res = left_root:join_hori(toroot)
-    		res = top_root:join_vert(res)
-    		res.my = top_root.h + toroot.my
-    	  g = res
-
-    	elseif name == "int" then
-    		g = grid:new(1, 1, { "∫" }, "sym")
-    	  g, exp_i = stack_subsup(explist, exp_i, g)
-    		local col_spacer = grid:new(1, 1, { " " })
-    		if g then
-    		  g = g:join_hori(col_spacer)
-    		end
-
-
-    	elseif name == "iint" then
-    		g = grid:new(1, 1, { "∬" }, "sym")
-
-    	  g, exp_i = stack_subsup(explist, exp_i, g)
-    		local col_spacer = grid:new(1, 1, { " " })
-    		if g then
-    		  g = g:join_hori(col_spacer)
-    		end
-
-
-    	elseif name == "iiint" then
-    		g = grid:new(1, 1, { "∭" }, "sym")
-
-    	  g, exp_i = stack_subsup(explist, exp_i, g)
-    		local col_spacer = grid:new(1, 1, { " " })
-    		if g then
-    		  g = g:join_hori(col_spacer)
-    		end
-
-
-    	elseif name == "oint" then
-    		g = grid:new(1, 1, { "∮" }, "sym")
-
-    	  g, exp_i = stack_subsup(explist, exp_i, g)
-    		local col_spacer = grid:new(1, 1, { " " })
-    		if g then
-    		  g = g:join_hori(col_spacer)
-    		end
-
-
-    	elseif name == "oiint" then
-    		g = grid:new(1, 1, { "∯" }, "sym")
-
-    	  g, exp_i = stack_subsup(explist, exp_i, g)
-    		local col_spacer = grid:new(1, 1, { " " })
-    		if g then
-    		  g = g:join_hori(col_spacer)
-    		end
-
-
-    	elseif name == "oiiint" then
-    		g = grid:new(1, 1, { "∰" }, "sym")
-
-    	  g, exp_i = stack_subsup(explist, exp_i, g)
-    		local col_spacer = grid:new(1, 1, { " " })
-    		if g then
-    		  g = g:join_hori(col_spacer)
-    		end
-
-
-    	elseif name == "sum" then
-    		g = grid:new(1, 1, { "∑" }, "sym")
-
-    	  g, exp_i = stack_subsup(explist, exp_i, g)
-    		local col_spacer = grid:new(1, 1, { " " })
-    		if g then
-    		  g = g:join_hori(col_spacer)
-    		end
-
-
-    	elseif name == "prod" then
-    		g = grid:new(1, 1, { "∏" }, "sym")
-
-    	  g, exp_i = stack_subsup(explist, exp_i, g)
-    		local col_spacer = grid:new(1, 1, { " " })
-    		if g then
-    		  g = g:join_hori(col_spacer)
-    		end
-
-
-    	elseif name == "lim" then
-    	  g = grid:new(3, 1, { "lim" }, "op")
-
-    	  g, exp_i = stack_subsup(explist, exp_i, g)
-    		local col_spacer = grid:new(1, 1, { " " })
-    		if g then
-    		  g = g:join_hori(col_spacer)
-    		end
-
-
-
-    	elseif name == "bar" then
-    	  local ingrid = to_ascii({explist[exp_i+1]}, 1)
-    	  exp_i = exp_i + 1
-    	  local bars = {}
-
-    	  local h = ingrid.h
-
-    	  for y=1,h do
-    	    table.insert(bars, style.root_vert_bar)
-    	  end
-
-    	  local left_bar = grid:new(1, h, bars)
-    	  local right_bar = grid:new(1, h, bars)
-
-    	  local  c1 = left_bar:join_hori(ingrid, true)
-    	  local  c2 = c1:join_hori(right_bar, true)
-    		g = c2
-
-
-    	elseif name == "hat" then
-    	  local belowgrid = to_ascii({explist[exp_i+1]}, 1)
-    	  exp_i = exp_i + 1
-    	  local hat = grid:new(1, 1, { "^" })
-    	  g = hat:join_vert(belowgrid)
-    	  g.my = belowgrid.my + 1
-    	elseif name == "mathbb" then
-    	  local sym = unpack_explist(explist[exp_i+1])
-    	  exp_i = exp_i + 1
-    		assert(sym.kind == "symexp" or sym.kind == "numexp", "mathbb must have 1 arguments")
-
-    	  local sym = tostring(sym.sym or sym.num)
-    		local cell = ""
-    		for i=1,#sym do
-    			assert(mathbb[sym:sub(i,i)], "mathbb " .. sym:sub(i,i) .. " symbol not found")
-    			cell = cell .. mathbb[sym:sub(i,i)]
-    		end
-    		g = grid:new(#sym, 1, {cell})
-    	elseif name == "mathbf" then
-    	  local sym = unpack_explist(explist[exp_i+1])
-    		g = to_ascii({explist[exp_i+1]}, 1)
-    	  exp_i = exp_i + 1
-    	elseif name == "mathcal" then
-    	  local sym = unpack_explist(explist[exp_i+1])
-    		-- assert(sym.kind == "symexp", "mathcal must have 1 arguments")
-    		if sym.kind == "symexp" then
-    			sym = sym.sym
-
-    			local cell = ""
-    			for i=1,#sym do
-    				assert(mathcal[sym:sub(i,i)], "mathcal " .. sym:sub(i,i) .. " symbol not found")
-    				cell = cell .. mathcal[sym:sub(i,i)]
-    			end
-    			g = grid:new(#sym, 1, {cell})
-    		elseif sym.kind == "funexp" then
-    			g = to_ascii({explist[exp_i+1]}, 1)
-    		else
-    			assert(false, "mathcal")
-    		end
-
-    		exp_i = exp_i + 1
-    	elseif name == "boldsymbol" then
-    	  local sym = unpack_explist(explist[exp_i+1])
-    		g = to_ascii({explist[exp_i+1]}, 1)
-    		exp_i = exp_i + 1
-
-    	elseif plain_functions[name] then
-    		g = grid:new(#name, 1, {name})
-    	elseif name == "overline" then
-    	  local belowgrid = to_ascii({explist[exp_i+1]}, 1)
-    	  exp_i = exp_i + 1
-
-    	  local bar = ""
-    	  local w = belowgrid.w
-    	  for x=1,w do
-    	  	bar = bar .. style.div_low_bar
-    	  end
-    	  local overline = grid:new(w, 1, { bar })
-    	  g = overline:join_vert(belowgrid)
-    	  g.my = belowgrid.my + 1
-
-    	elseif name == "vec" then
-    	  local belowgrid = to_ascii({explist[exp_i+1]}, 1)
-    	  exp_i = exp_i + 1
-    	  local txt = ""
-    	  local w = belowgrid.w
-    	  for x=1,w-1 do
-    	  	txt = txt .. style.div_middle_bar
-    	  end
-    	  txt = txt .. style.vec_arrow
-
-    	  local arrow = grid:new(w, 1, {txt})
-    	  g = arrow:join_vert(belowgrid)
-    	  g.my = belowgrid.my + 1
-
-      elseif name == "{" then
-        local inside_bra = {}
-        while exp_i+1 <= #explist do
-          if explist[exp_i+1].kind == "funexp" and explist[exp_i+1].sym == "}" then
-            break
-          end
-          table.insert(inside_bra, explist[exp_i+1])
-          exp_i = exp_i + 1
-        end
-
-        assert(explist[exp_i+1] and explist[exp_i+1].kind == "funexp" and explist[exp_i+1].sym == "}", "No matching closing bracket")
-
-      	g = to_ascii(inside_bra, 1):enclose_bracket()
-      	exp_i = exp_i + 1
-
-    	else
-    		g = grid:new(utf8len("\\" .. name), 1, { "\\" .. name })
-    	end
-
-
-    elseif exp.kind == "parexp" then
-    	g = to_ascii({exp.exp}, 1):enclose_paren()
-
-    elseif exp.kind == "blockexp" then
-      local sym = unpack_explist(exp.first)
-      exp_i = exp_i + 1
-      local name = sym.sym
-      if name == "matrix" then
-        local cellsgrid, maxheight = grid_of_exps(exp.content.exps)
-        local res = combine_matrix_grid(cellsgrid, maxheight)
-
-        res.my = math.floor(res.h/2)
-        g = res
-
-      elseif name == "align" or name == "aligned" then
-        local cellsgrid, maxheight = grid_of_exps(exp.content.exps)
-        local res = combine_matrix_grid(cellsgrid, maxheight)
-        res.my = math.floor(res.h/2)
-        g = res
-      elseif name == "pmatrix" then
-        local cellsgrid, maxheight = grid_of_exps(exp.content.exps)
-        local res = combine_matrix_grid(cellsgrid, maxheight)
-        res.my = math.floor(res.h/2)
-        g = res:enclose_paren()
-
-      elseif name == "bmatrix" then
-        local cellsgrid, maxheight = grid_of_exps(exp.content.exps)
-        local res = combine_matrix_grid(cellsgrid, maxheight)
-        res = combine_brackets(res)
-
-        res.my = math.floor(res.h/2)
-        g = res
-
-      else
-        error("Unknown block expression " .. name)
-      end
-
-
-    elseif exp.kind == "supexp" or exp.kind == "subexp" then
-      assert(#gs >= 1, "No expression preceding '^'")
-      local sub, sup
-      while exp_i <= #explist do
-        if explist[exp_i].kind == "subexp" then
-          sub = explist[exp_i+1]
-          exp_i = exp_i + 2
-        elseif explist[exp_i].kind == "supexp" then
-          sup = explist[exp_i+1]
-          exp_i = exp_i + 2
+    local gs = {}
+    while exp_i <= #explist do
+        local exp = explist[exp_i]
+        local g
+        if exp.kind == "numexp" then
+            local numstr = tostring(exp.num)
+            g = grid:new(string.len(numstr), 1, { tostring(numstr) }, "num")
+        elseif exp.kind == "symexp" then
+            local sym = exp.sym
+            if
+                not string.match(sym, "^%a")
+                and not string.match(sym, "^%d")
+                and not string.match(sym, "^%s+$")
+                and sym ~= "/"
+                and sym ~= special_syms["partial"]
+                and sym ~= "["
+                and sym ~= "]"
+                and sym ~= "'"
+                and sym ~= "|"
+                and sym ~= "."
+                and sym ~= ","
+                and not (exp_i == 1 and sym == "-")
+                and sym ~= special_syms["Vert"]
+            then
+                sym = " " .. sym .. " "
+            end
+
+            g = grid:new(utf8len(sym), 1, { sym }, "sym")
+        elseif exp.kind == "explist" then
+            g = to_ascii(exp.exps, 1)
+        elseif exp.kind == "funexp" then
+            local name = exp.sym
+            if name == "frac" then
+                local leftgrid = to_ascii({ explist[exp_i + 1] }, 1)
+                local rightgrid = to_ascii({ explist[exp_i + 2] }, 1)
+                exp_i = exp_i + 2
+
+                local bar = ""
+                local w = math.max(leftgrid.w, rightgrid.w)
+                for x = 1, w do
+                    bar = bar .. style.div_middle_bar
+                end
+
+                local opgrid = grid:new(w, 1, { bar })
+
+                local c1 = leftgrid:join_vert(opgrid)
+                local c2 = c1:join_vert(rightgrid)
+                c2.my = leftgrid.h
+
+                g = c2
+            elseif special_syms[name] or special_nums[name] or greek_etc[name] then
+                local sym = special_syms[name] or special_nums[name] or greek_etc[name]
+                local t
+                if special_syms[name] then
+                    t = "sym"
+                    if
+                        not string.match(sym, "^%a")
+                        and not string.match(sym, "^%d")
+                        and not string.match(sym, "^%s+$")
+                        and sym ~= "/"
+                        and sym ~= special_syms["partial"]
+                        and sym ~= "["
+                        and sym ~= "]"
+                        and sym ~= "'"
+                        and sym ~= "|"
+                        and sym ~= "."
+                        and sym ~= ","
+                        and not (exp_i == 1 and sym == "-")
+                        and sym ~= special_syms["Vert"]
+                    then
+                        sym = " " .. sym .. " "
+                    end
+                elseif special_nums[name] then
+                    t = "num"
+                elseif greek_etc[name] then
+                    t = "var"
+                end
+
+                g = grid:new(utf8len(sym), 1, { sym }, t)
+            elseif name == "sqrt" then
+                local toroot = to_ascii({ explist[exp_i + 1] }, 1)
+                exp_i = exp_i + 1
+
+                local left_content = {}
+                for y = 1, toroot.h do
+                    if y < toroot.h then
+                        table.insert(left_content, " " .. style.root_vert_bar)
+                    else
+                        table.insert(left_content, style.root_bottom .. style.root_vert_bar)
+                    end
+                end
+
+                local left_root = grid:new(2, toroot.h, left_content, "sym")
+                left_root.my = toroot.my
+
+                local up_str = " " .. style.root_upper_left
+                for x = 1, toroot.w do
+                    up_str = up_str .. style.root_upper
+                end
+                up_str = up_str .. style.root_upper_right
+
+                local top_root = grid:new(toroot.w + 2, 1, { up_str }, "sym")
+
+                local res = left_root:join_hori(toroot)
+                res = top_root:join_vert(res)
+                res.my = top_root.h + toroot.my
+                g = res
+            elseif name == "int" then
+                g = grid:new(1, 1, { "∫" }, "sym")
+                g, exp_i = stack_subsup(explist, exp_i, g)
+                local col_spacer = grid:new(1, 1, { " " })
+                if g then g = g:join_hori(col_spacer) end
+            elseif name == "iint" then
+                g = grid:new(1, 1, { "∬" }, "sym")
+
+                g, exp_i = stack_subsup(explist, exp_i, g)
+                local col_spacer = grid:new(1, 1, { " " })
+                if g then g = g:join_hori(col_spacer) end
+            elseif name == "iiint" then
+                g = grid:new(1, 1, { "∭" }, "sym")
+
+                g, exp_i = stack_subsup(explist, exp_i, g)
+                local col_spacer = grid:new(1, 1, { " " })
+                if g then g = g:join_hori(col_spacer) end
+            elseif name == "oint" then
+                g = grid:new(1, 1, { "∮" }, "sym")
+
+                g, exp_i = stack_subsup(explist, exp_i, g)
+                local col_spacer = grid:new(1, 1, { " " })
+                if g then g = g:join_hori(col_spacer) end
+            elseif name == "oiint" then
+                g = grid:new(1, 1, { "∯" }, "sym")
+
+                g, exp_i = stack_subsup(explist, exp_i, g)
+                local col_spacer = grid:new(1, 1, { " " })
+                if g then g = g:join_hori(col_spacer) end
+            elseif name == "oiiint" then
+                g = grid:new(1, 1, { "∰" }, "sym")
+
+                g, exp_i = stack_subsup(explist, exp_i, g)
+                local col_spacer = grid:new(1, 1, { " " })
+                if g then g = g:join_hori(col_spacer) end
+            elseif name == "sum" then
+                g = grid:new(1, 1, { "∑" }, "sym")
+
+                g, exp_i = stack_subsup(explist, exp_i, g)
+                local col_spacer = grid:new(1, 1, { " " })
+                if g then g = g:join_hori(col_spacer) end
+            elseif name == "prod" then
+                g = grid:new(1, 1, { "∏" }, "sym")
+
+                g, exp_i = stack_subsup(explist, exp_i, g)
+                local col_spacer = grid:new(1, 1, { " " })
+                if g then g = g:join_hori(col_spacer) end
+            elseif name == "lim" then
+                g = grid:new(3, 1, { "lim" }, "op")
+
+                g, exp_i = stack_subsup(explist, exp_i, g)
+                local col_spacer = grid:new(1, 1, { " " })
+                if g then g = g:join_hori(col_spacer) end
+            elseif name == "bar" then
+                local ingrid = to_ascii({ explist[exp_i + 1] }, 1)
+                exp_i = exp_i + 1
+                local bars = {}
+
+                local h = ingrid.h
+
+                for y = 1, h do
+                    table.insert(bars, style.root_vert_bar)
+                end
+
+                local left_bar = grid:new(1, h, bars)
+                local right_bar = grid:new(1, h, bars)
+
+                local c1 = left_bar:join_hori(ingrid, true)
+                local c2 = c1:join_hori(right_bar, true)
+                g = c2
+            elseif name == "hat" then
+                local belowgrid = to_ascii({ explist[exp_i + 1] }, 1)
+                exp_i = exp_i + 1
+                local hat = grid:new(1, 1, { "^" })
+                g = hat:join_vert(belowgrid)
+                g.my = belowgrid.my + 1
+            elseif name == "mathbb" then
+                local sym = unpack_explist(explist[exp_i + 1])
+                exp_i = exp_i + 1
+                assert(sym.kind == "symexp" or sym.kind == "numexp", "mathbb must have 1 arguments")
+
+                local sym = tostring(sym.sym or sym.num)
+                local cell = ""
+                for i = 1, #sym do
+                    assert(mathbb[sym:sub(i, i)], "mathbb " .. sym:sub(i, i) .. " symbol not found")
+                    cell = cell .. mathbb[sym:sub(i, i)]
+                end
+                g = grid:new(#sym, 1, { cell })
+            elseif name == "mathbf" then
+                local sym = unpack_explist(explist[exp_i + 1])
+                g = to_ascii({ explist[exp_i + 1] }, 1)
+                exp_i = exp_i + 1
+            elseif name == "mathcal" then
+                local sym = unpack_explist(explist[exp_i + 1])
+                -- assert(sym.kind == "symexp", "mathcal must have 1 arguments")
+                if sym.kind == "symexp" then
+                    sym = sym.sym
+
+                    local cell = ""
+                    for i = 1, #sym do
+                        assert(mathcal[sym:sub(i, i)], "mathcal " .. sym:sub(i, i) .. " symbol not found")
+                        cell = cell .. mathcal[sym:sub(i, i)]
+                    end
+                    g = grid:new(#sym, 1, { cell })
+                elseif sym.kind == "funexp" then
+                    g = to_ascii({ explist[exp_i + 1] }, 1)
+                else
+                    assert(false, "mathcal")
+                end
+
+                exp_i = exp_i + 1
+            elseif name == "boldsymbol" then
+                local sym = unpack_explist(explist[exp_i + 1])
+                g = to_ascii({ explist[exp_i + 1] }, 1)
+                exp_i = exp_i + 1
+            elseif plain_functions[name] then
+                g = grid:new(#name, 1, { name })
+            elseif name == "overline" then
+                local belowgrid = to_ascii({ explist[exp_i + 1] }, 1)
+                exp_i = exp_i + 1
+
+                local bar = ""
+                local w = belowgrid.w
+                for x = 1, w do
+                    bar = bar .. style.div_low_bar
+                end
+                local overline = grid:new(w, 1, { bar })
+                g = overline:join_vert(belowgrid)
+                g.my = belowgrid.my + 1
+            elseif name == "vec" then
+                local belowgrid = to_ascii({ explist[exp_i + 1] }, 1)
+                exp_i = exp_i + 1
+                local txt = ""
+                local w = belowgrid.w
+                for x = 1, w - 1 do
+                    txt = txt .. style.div_middle_bar
+                end
+                txt = txt .. style.vec_arrow
+
+                local arrow = grid:new(w, 1, { txt })
+                g = arrow:join_vert(belowgrid)
+                g.my = belowgrid.my + 1
+            elseif name == "{" then
+                local inside_bra = {}
+                while exp_i + 1 <= #explist do
+                    if explist[exp_i + 1].kind == "funexp" and explist[exp_i + 1].sym == "}" then break end
+                    table.insert(inside_bra, explist[exp_i + 1])
+                    exp_i = exp_i + 1
+                end
+
+                assert(
+                    explist[exp_i + 1] and explist[exp_i + 1].kind == "funexp" and explist[exp_i + 1].sym == "}",
+                    "No matching closing bracket"
+                )
+
+                g = to_ascii(inside_bra, 1):enclose_bracket()
+                exp_i = exp_i + 1
+            else
+                g = grid:new(utf8len("\\" .. name), 1, { "\\" .. name })
+            end
+        elseif exp.kind == "parexp" then
+            g = to_ascii({ exp.exp }, 1):enclose_paren()
+        elseif exp.kind == "blockexp" then
+            local sym = unpack_explist(exp.first)
+            exp_i = exp_i + 1
+            local name = sym.sym
+            if name == "matrix" then
+                local cellsgrid, maxheight = grid_of_exps(exp.content.exps)
+                local res = combine_matrix_grid(cellsgrid, maxheight)
+
+                res.my = math.floor(res.h / 2)
+                g = res
+            elseif name == "align" or name == "aligned" then
+                local cellsgrid, maxheight = grid_of_exps(exp.content.exps)
+                local res = combine_matrix_grid(cellsgrid, maxheight)
+                res.my = math.floor(res.h / 2)
+                g = res
+            elseif name == "pmatrix" then
+                local cellsgrid, maxheight = grid_of_exps(exp.content.exps)
+                local res = combine_matrix_grid(cellsgrid, maxheight)
+                res.my = math.floor(res.h / 2)
+                g = res:enclose_paren()
+            elseif name == "bmatrix" then
+                local cellsgrid, maxheight = grid_of_exps(exp.content.exps)
+                local res = combine_matrix_grid(cellsgrid, maxheight)
+                res = combine_brackets(res)
+
+                res.my = math.floor(res.h / 2)
+                g = res
+            else
+                error("Unknown block expression " .. name)
+            end
+        elseif exp.kind == "supexp" or exp.kind == "subexp" then
+            assert(#gs >= 1, "No expression preceding '^'")
+            local sub, sup
+            while exp_i <= #explist do
+                if explist[exp_i].kind == "subexp" then
+                    sub = explist[exp_i + 1]
+                    exp_i = exp_i + 2
+                elseif explist[exp_i].kind == "supexp" then
+                    sup = explist[exp_i + 1]
+                    exp_i = exp_i + 2
+                else
+                    break
+                end
+            end
+            exp_i = exp_i - 1
+
+            if sup and sup.kind ~= "explist" then
+                if sup.kind == "funexp" and explist[exp_i + 1] and explist[exp_i + 1].kind == "explist" then
+                    sup = {
+                        kind = "explist",
+                        exps = { sup, explist[exp_i + 1] },
+                    }
+                    exp_i = exp_i + 1
+                else
+                    sup = {
+                        kind = "explist",
+                        exps = { sup },
+                    }
+                end
+            end
+
+            if sub and sub.kind ~= "explist" then
+                if sub.kind == "funexp" and explist[exp_i + 1] and explist[exp_i + 1].kind == "explist" then
+                    sub = {
+                        kind = "explist",
+                        exps = { sub, explist[exp_i + 1] },
+                    }
+                    exp_i = exp_i + 1
+                else
+                    sub = {
+                        kind = "explist",
+                        exps = { sub },
+                    }
+                end
+            end
+
+            local last_g = gs[#gs]
+            last_g = put_subsup_aside(last_g, sub, sup)
+            last_g = put_if_only_sub(last_g, sub, sup)
+            last_g = put_if_only_sup(last_g, sub, sup)
+            gs[#gs] = last_g
+        elseif exp.kind == "chosexp" then
+            -- same thing as frac without the bar
+            local leftgrid = to_ascii({ exp.left }, 1)
+            local rightgrid = to_ascii({ exp.right }, 1)
+
+            local bar = ""
+            local w = math.max(leftgrid.w, rightgrid.w)
+            for x = 1, w do
+                bar = bar .. " "
+            end
+
+            local opgrid = grid:new(w, 1, { bar })
+
+            local c1 = leftgrid:join_vert(opgrid)
+            local c2 = c1:join_vert(rightgrid)
+            c2.my = leftgrid.h
+
+            g = c2:enclose_paren()
+        elseif exp.kind == "braexp" then
+            g = to_ascii({ exp.exp }, 1)
+            g = combine_brackets(g)
         else
-          break
+            assert(false, "Unrecognized token")
         end
-      end
-      exp_i = exp_i - 1
 
-      if sup and sup.kind ~= "explist" then
-    		if sup.kind == "funexp" and explist[exp_i+1] and explist[exp_i+1].kind == "explist" then
-    			sup = {
-    				kind = "explist",
-    				exps = { sup, explist[exp_i+1] },
-    			}
-    			exp_i = exp_i + 1
-
-    		else
-    			sup = {
-    				kind = "explist",
-    				exps = { sup },
-    			}
-    		end
-      end
-
-      if sub and sub.kind ~= "explist" then
-    		if sub.kind == "funexp" and explist[exp_i+1] and explist[exp_i+1].kind == "explist" then
-    			sub = {
-    				kind = "explist",
-    				exps = { sub, explist[exp_i+1] },
-    			}
-    			exp_i = exp_i + 1
-
-    		else
-    			sub = {
-    				kind = "explist",
-    				exps = { sub },
-    			}
-    		end
-      end
-
-      local last_g = gs[#gs]
-      last_g = put_subsup_aside(last_g, sub, sup)
-      last_g = put_if_only_sub(last_g, sub, sup)
-      last_g = put_if_only_sup(last_g, sub, sup)
-      gs[#gs] = last_g
-
-    elseif exp.kind == "chosexp" then
-      -- same thing as frac without the bar
-      local leftgrid = to_ascii({exp.left}, 1)
-      local rightgrid = to_ascii({exp.right}, 1)
-      
-    	local bar = ""
-    	local w = math.max(leftgrid.w, rightgrid.w)
-    	for x=1,w do
-    		bar = bar .. " "
-    	end
-
-    	local opgrid = grid:new(w, 1, { bar })
-
-    	local c1 = leftgrid:join_vert(opgrid)
-    	local c2 = c1:join_vert(rightgrid)
-    	c2.my = leftgrid.h
-
-
-      g = c2:enclose_paren()
-
-    elseif exp.kind == "braexp" then
-    	g = to_ascii({exp.exp}, 1)
-      g = combine_brackets(g)
-    else
-      assert(false, "Unrecognized token")
+        table.insert(gs, g)
+        exp_i = exp_i + 1
+    end
+    local concat_g = grid:new()
+    for _, g in ipairs(gs) do
+        if g then concat_g = concat_g:join_hori(g) end
     end
 
-    table.insert(gs, g)
-    exp_i = exp_i + 1
-  end
-  local concat_g = grid:new()
-  for _, g in ipairs(gs) do
-    if g then
-      concat_g = concat_g:join_hori(g)
-    end
-  end
-
-	return concat_g
+    return concat_g
 end
 
-function utf8len(str)
-	return vim.str_utfindex(str)
-end
+function utf8len(str) return vim.str_utfindex(str) end
 
 function utf8char(str, i)
-	if i >= utf8len(str) or i < 0 then return nil end
-	local s1 = vim.str_byteindex(str, i)
-	local s2 = vim.str_byteindex(str, i+1)
-	return string.sub(str, s1+1, s2)
+    if i >= utf8len(str) or i < 0 then return nil end
+    local s1 = vim.str_byteindex(str, i)
+    local s2 = vim.str_byteindex(str, i + 1)
+    return string.sub(str, s1 + 1, s2)
 end
 
-
 return {
-to_ascii = to_ascii,
-
+    to_ascii = to_ascii,
 }
-

--- a/lua/nabla/latex.lua
+++ b/lua/nabla/latex.lua
@@ -17,12 +17,12 @@ local lookahead
 
 local M = {}
 function M.parse_all(str)
-	buf = str
-	ptr = 1
+    buf = str
+    ptr = 1
 
-  lnum = 1
-	local exp = parse()
-	return exp
+    lnum = 1
+    local exp = parse()
+    return exp
 end
 
 function getc() return string.sub(buf, ptr, ptr) end
@@ -30,313 +30,279 @@ function nextc() ptr = ptr + 1 end
 function finish() return ptr > string.len(buf) end
 
 function parse()
+    local explist = {
+        kind = "explist",
+        exps = {},
+        lnum = lnum,
+    }
 
-	local explist = {
-		kind = "explist",
-		exps = {},
-    lnum = lnum,
-	}
+    local chosexp
 
-  local chosexp
+    while not finish() do
+        local exp
 
-	while not finish() do
-		local exp
+        skip_ws()
 
-		skip_ws()
-
-		if string.match(getc(), "}") then
-			nextc()
-			break
-		end
-
-		if getc() == ")" then
-			nextc()
-			break
-		end
-
-
-		if string.match(getc(), "%d") then
-			exp = parse_number()
-
-		elseif string.match(getc(), "\\") then
-			nextc()
-			local sym
-			if getc() == " " then
-				sym = {
-					kind = "symexp",
-			    lnum = lnum,
-					sym = "      ",
-				}
-				nextc()
-
-		  elseif getc() == ":" then
-		  	sym = {
-		  		kind = "symexp",
-		      lnum = lnum,
-		  		sym = "    ",
-		  	}
-		  	nextc()
-		  elseif getc() == ";" then
-		  	sym = {
-		  		kind = "symexp",
-		      lnum = lnum,
-		  		sym = "     ",
-		  	}
-		  	nextc()
-
-		  elseif getc() == "\\" then
-		    sym = {
-		      kind = "symexp",
-		      sym = "\\",
-		      lnum = lnum,
-		    }
-		    nextc()
-		  elseif getc() == "{" then
-		  	nextc()
-		    sym = {
-		      kind = "symexp", 
-		      lnum = lnum,
-		      sym = "{", 
-		    }
-
-		  elseif getc() == "}" then
-		    nextc()
-		    sym = {
-		      kind = "symexp", 
-		      lnum = lnum,
-		      sym = "}", 
-		    }
-
-		  elseif getc() == "," then
-		  	sym = {
-		  		kind = "symexp",
-		      lnum = lnum,
-		  		sym = " ",
-		  	}
-		  	nextc()
-
-			elseif getc() == "|" then
-				sym = {
-					kind = "funexp",
-			    lnum = lnum,
-					sym = "Vert",
-				}
-				nextc()
-			else
-				sym = parse_symbol()
-			end
-		  if (sym.sym == "text" or sym.sym == "texttt") and string.match(getc(), '{') then
-		    nextc()
-		    local txt = ""
-		  	while not finish() and not string.match(getc(), '}') do
-		      txt = txt .. getc()
-		      nextc()
-		    end
-		    nextc()
-
-		    exp = {
-		      kind = "symexp",
-		      lnum = lnum,
-		      sym  = txt,
-		    }
-
-
-		  elseif sym.sym == "quad" then
-		  	exp = {
-		  		kind = "symexp",
-		      lnum = lnum,
-		  		sym = "       ",
-		  	}
-		  elseif sym.sym == "qquad" then
-		  	exp = {
-		  		kind = "symexp",
-		      lnum = lnum,
-		  		sym = "        ",
-		  	}
-
-		  elseif sym.sym == "choose" then
-		    assert(#explist.exps > 0)
-		    local left = explist.exps[#explist.exps]
-		    table.remove(explist.exps)
-
-		    chosexp = {
-		      kind = "chosexp",
-		      lnum = lnum,
-		      left = nil,
-		      right = nil
-		    }
-
-		    table.insert(explist.exps, chosexp)
-		    exp = left
-
-		  elseif sym.sym:sub(1,1) == " " then
-		  	exp = {
-		  		kind = "symexp",
-		      lnum = lnum,
-		  		sym = " ",
-		  	}
-
-		  elseif sym.sym == "left" and string.match(getc(), '%(') then
-		    nextc()
-		  	local in_exp = parse()
-		    exp = {
-		      kind = "parexp",
-		      lnum = lnum,
-		      exp = in_exp,
-		    }
-		  elseif sym.sym == "right" and string.match(getc(), '%)') then
-		    nextc()
-		    break
-
-		  elseif sym.sym == "left" and string.match(getc(), '%[') then
-		    nextc()
-		  	local in_exp = parse()
-		    exp = {
-		      kind = "braexp",
-		      lnum = lnum,
-		      exp = in_exp,
-		    }
-		  elseif sym.sym == "right" and string.match(getc(), '%]') then
-		    nextc()
-		    break
-
-		  else
-		    exp = {
-		    	kind = "funexp",
-		    	sym = sym.sym,
-		      lnum = lnum,
-		    }
-
-
-		    if sym.sym == "begin" then
-		    	local explist = parse()
-		      local block_name = explist.exps[1]
-		      table.remove(explist.exps, 1)
-
-		    	exp = {
-		    		kind = "blockexp",
-		        lnum = lnum,
-		        first = block_name,
-		    		content = explist,
-		    	}
-
-		    elseif sym.sym == "end" then
-		      break
-		    end
-
-		  end
-
-		elseif string.match(getc(), "%a") then
-			exp = parse_symbol()
-
-    elseif string.match(getc(), "{") then
-      nextc()
-      exp = parse()
-
-		else
-			if getc() == "_" then
-				assert(#explist.exps > 0, "subscript no preceding token")
-				nextc()
-			  exp = {
-			    kind = "subexp",
-			    lnum = lnum,
-			  }
-
-			elseif getc() == "^" then
-				assert(#explist.exps > 0, "superscript no preceding token")
-				nextc()
-			  exp = {
-			    kind = "supexp",
-			    lnum = lnum,
-			  }
-
-			elseif getc() == "(" then
-				nextc()
-				local in_exp = parse()
-				exp = {
-					kind = "parexp",
-			    lnum = lnum,
-					exp = in_exp,
-				}
-
-			elseif getc() == "/" and lookahead(1) == "/" then
-				exp = {
-					kind = "symexp",
-			    lnum = lnum,
-					sym = "//",
-				}
-				nextc()
-				nextc()
-
-			else 
-				exp = {
-					kind = "symexp",
-			    lnum = lnum,
-					sym = getc(),
-				}
-				nextc()
-			end
-
-		end
-
-
-
-		if exp then
-      if chosexp then
-        if not chosexp.left then
-          chosexp.left = exp
-        elseif not chosexp.right then
-          chosexp.right = exp
-          chosexp = nil
+        if string.match(getc(), "}") then
+            nextc()
+            break
         end
 
-      else
-        table.insert(explist.exps, exp)
-      end
-		end
-	end
+        if getc() == ")" then
+            nextc()
+            break
+        end
 
-	return explist
+        if string.match(getc(), "%d") then
+            exp = parse_number()
+        elseif string.match(getc(), "\\") then
+            nextc()
+            local sym
+            if getc() == " " then
+                sym = {
+                    kind = "symexp",
+                    lnum = lnum,
+                    sym = "      ",
+                }
+                nextc()
+            elseif getc() == ":" then
+                sym = {
+                    kind = "symexp",
+                    lnum = lnum,
+                    sym = "    ",
+                }
+                nextc()
+            elseif getc() == ";" then
+                sym = {
+                    kind = "symexp",
+                    lnum = lnum,
+                    sym = "     ",
+                }
+                nextc()
+            elseif getc() == "\\" then
+                sym = {
+                    kind = "symexp",
+                    sym = "\\",
+                    lnum = lnum,
+                }
+                nextc()
+            elseif getc() == "{" then
+                nextc()
+                sym = {
+                    kind = "symexp",
+                    lnum = lnum,
+                    sym = "{",
+                }
+            elseif getc() == "}" then
+                nextc()
+                sym = {
+                    kind = "symexp",
+                    lnum = lnum,
+                    sym = "}",
+                }
+            elseif getc() == "," then
+                sym = {
+                    kind = "symexp",
+                    lnum = lnum,
+                    sym = " ",
+                }
+                nextc()
+            elseif getc() == "|" then
+                sym = {
+                    kind = "funexp",
+                    lnum = lnum,
+                    sym = "Vert",
+                }
+                nextc()
+            else
+                sym = parse_symbol()
+            end
+            if (sym.sym == "text" or sym.sym == "texttt") and string.match(getc(), "{") then
+                nextc()
+                local txt = ""
+                while not finish() and not string.match(getc(), "}") do
+                    txt = txt .. getc()
+                    nextc()
+                end
+                nextc()
+
+                exp = {
+                    kind = "symexp",
+                    lnum = lnum,
+                    sym = txt,
+                }
+            elseif sym.sym == "quad" then
+                exp = {
+                    kind = "symexp",
+                    lnum = lnum,
+                    sym = "       ",
+                }
+            elseif sym.sym == "qquad" then
+                exp = {
+                    kind = "symexp",
+                    lnum = lnum,
+                    sym = "        ",
+                }
+            elseif sym.sym == "choose" then
+                assert(#explist.exps > 0)
+                local left = explist.exps[#explist.exps]
+                table.remove(explist.exps)
+
+                chosexp = {
+                    kind = "chosexp",
+                    lnum = lnum,
+                    left = nil,
+                    right = nil,
+                }
+
+                table.insert(explist.exps, chosexp)
+                exp = left
+            elseif sym.sym:sub(1, 1) == " " then
+                exp = {
+                    kind = "symexp",
+                    lnum = lnum,
+                    sym = " ",
+                }
+            elseif sym.sym == "left" and string.match(getc(), "%(") then
+                nextc()
+                local in_exp = parse()
+                exp = {
+                    kind = "parexp",
+                    lnum = lnum,
+                    exp = in_exp,
+                }
+            elseif sym.sym == "right" and string.match(getc(), "%)") then
+                nextc()
+                break
+            elseif sym.sym == "left" and string.match(getc(), "%[") then
+                nextc()
+                local in_exp = parse()
+                exp = {
+                    kind = "braexp",
+                    lnum = lnum,
+                    exp = in_exp,
+                }
+            elseif sym.sym == "right" and string.match(getc(), "%]") then
+                nextc()
+                break
+            else
+                exp = {
+                    kind = "funexp",
+                    sym = sym.sym,
+                    lnum = lnum,
+                }
+
+                if sym.sym == "begin" then
+                    local explist = parse()
+                    local block_name = explist.exps[1]
+                    table.remove(explist.exps, 1)
+
+                    exp = {
+                        kind = "blockexp",
+                        lnum = lnum,
+                        first = block_name,
+                        content = explist,
+                    }
+                elseif sym.sym == "end" then
+                    break
+                end
+            end
+        elseif string.match(getc(), "%a") then
+            exp = parse_symbol()
+        elseif string.match(getc(), "{") then
+            nextc()
+            exp = parse()
+        else
+            if getc() == "_" then
+                assert(#explist.exps > 0, "subscript no preceding token")
+                nextc()
+                exp = {
+                    kind = "subexp",
+                    lnum = lnum,
+                }
+            elseif getc() == "^" then
+                assert(#explist.exps > 0, "superscript no preceding token")
+                nextc()
+                exp = {
+                    kind = "supexp",
+                    lnum = lnum,
+                }
+            elseif getc() == "(" then
+                nextc()
+                local in_exp = parse()
+                exp = {
+                    kind = "parexp",
+                    lnum = lnum,
+                    exp = in_exp,
+                }
+            elseif getc() == "/" and lookahead(1) == "/" then
+                exp = {
+                    kind = "symexp",
+                    lnum = lnum,
+                    sym = "//",
+                }
+                nextc()
+                nextc()
+            else
+                exp = {
+                    kind = "symexp",
+                    lnum = lnum,
+                    sym = getc(),
+                }
+                nextc()
+            end
+        end
+
+        if exp then
+            if chosexp then
+                if not chosexp.left then
+                    chosexp.left = exp
+                elseif not chosexp.right then
+                    chosexp.right = exp
+                    chosexp = nil
+                end
+            else
+                table.insert(explist.exps, exp)
+            end
+        end
+    end
+
+    return explist
 end
 
 function skip_ws()
-	while not finish() and string.match(getc(), "%s") do
-    if getc() == "\n" then
-      lnum = lnum + 1
+    while not finish() and string.match(getc(), "%s") do
+        if getc() == "\n" then lnum = lnum + 1 end
+        nextc()
     end
-		nextc()
-	end
 end
 
 function parse_number()
-	local rest = string.sub(buf, ptr)
-	local num_str = string.match(rest, "^%d+%.?%d*")
-	ptr = ptr + string.len(num_str)
-	local exp = {
-		kind = "numexp",
-		num = tonumber(num_str),
-	  lnum = lnum,
-	}
+    local rest = string.sub(buf, ptr)
+    local num_str = string.match(rest, "^%d+%.?%d*")
+    ptr = ptr + string.len(num_str)
+    local exp = {
+        kind = "numexp",
+        num = tonumber(num_str),
+        lnum = lnum,
+    }
 
-	return exp
+    return exp
 end
 
 function parse_symbol()
-	local rest = string.sub(buf, ptr)
-	local sym_str = string.match(rest, "^%a+")
-	ptr = ptr + string.len(sym_str)
-	local exp = {
-		kind = "symexp",
-		sym = sym_str,
-	  lnum = lnum,
-	}
+    local rest = string.sub(buf, ptr)
+    local sym_str = string.match(rest, "^%a+")
+    ptr = ptr + string.len(sym_str)
+    local exp = {
+        kind = "symexp",
+        sym = sym_str,
+        lnum = lnum,
+    }
 
-	return exp
+    return exp
 end
 
-function lookahead(i)
-	return string.sub(buf, ptr+i, ptr+i)
-end
+function lookahead(i) return string.sub(buf, ptr + i, ptr + i) end
 
 return M
-

--- a/lua/nabla/utils.lua
+++ b/lua/nabla/utils.lua
@@ -71,7 +71,7 @@ utils.get_all_mathzones = function()
     local ok, parser = pcall(ts.get_parser, buf, "latex")
     if not ok or not parser then
         vim.api.nvim_echo(
-            { { 'Latex parser not found. Please install with nvim-tresitter using ":TSInstall latex".', "ErrorMsg" } },
+            { { 'Latex parser not found. Please install with nvim-treesitter using ":TSInstall latex".', "ErrorMsg" } },
             true,
             {}
         )

--- a/src/treesitter/detect_for_virt_lines.lua.t
+++ b/src/treesitter/detect_for_virt_lines.lua.t
@@ -7,7 +7,7 @@ utils.get_all_mathzones = function()
 end
 
 @warn_if_latex_is_not_installed+=
-vim.api.nvim_echo({{"Latex parser not found. Please install with nvim-tresitter using \":TSInstall latex\".", "ErrorMsg"}}, true, {})
+vim.api.nvim_echo({{"Latex parser not found. Please install with nvim-treesitter using \":TSInstall latex\".", "ErrorMsg"}}, true, {})
 
 @get_tree_root_ts+=
 local buf = vim.api.nvim_get_current_buf()

--- a/src/treesitter/detect_mathzone.lua.t
+++ b/src/treesitter/detect_mathzone.lua.t
@@ -25,7 +25,7 @@ utils.in_mathzone = function()
         local ok, parser = pcall(ts.get_parser, buf, "latex")
         if not ok or not parser then
           @warn_if_latex_is_not_installed
-            vim.api.nvim_echo({{"Latex parser not found. Please install with nvim-tresitter using \":TSInstall latex\".", "ErrorMsg"}}, true, {})
+            vim.api.nvim_echo({{"Latex parser not found. Please install with nvim-treesitter using \":TSInstall latex\".", "ErrorMsg"}}, true, {})
             return
         end
         local root_tree = parser:parse()[1]

--- a/test/test.lua
+++ b/test/test.lua
@@ -3,9 +3,7 @@ local fail = false
 
 local info = debug.getinfo(1, "S")
 local path
-if info and info.source:sub(1, 1) == "@" then
-  path = vim.fn.fnamemodify(info.source:sub(2), ":p")
-end
+if info and info.source:sub(1, 1) == "@" then path = vim.fn.fnamemodify(info.source:sub(2), ":p") end
 path = vim.fn.fnamemodify(path, ":h:h")
 local nabla_path = path
 
@@ -13,70 +11,67 @@ path = path .. "/test/cases"
 
 -- local add = [[\\.\pipe\nvim-24652-0]]
 -- local conn = vim.fn.sockconnect("pipe", add, {rpc = true})
-local conn = vim.fn.jobstart({vim.v.progpath, '--embed', '--headless'}, {rpc = true})
-
+local conn = vim.fn.jobstart({ vim.v.progpath, "--embed", "--headless" }, { rpc = true })
 
 local files = {}
 local all_files = vim.fn.glob(path .. "/*")
 for _, file in ipairs(vim.split(all_files, "\n")) do
-  table.insert(files, file)
+    table.insert(files, file)
 end
 
 for _, file in ipairs(files) do
-  local lines = {}
-  local input = {}
-  local output = {}
-  local in_input = true
-  for line in io.lines(file) do
-    if in_input then
-      if string.match(line, "^%-%-%-") then
-        in_input = false
-      else
-        table.insert(input, line)
-      end
-    else
-      table.insert(output, line)
-    end
-  end
-
-  local result = vim.fn.rpcrequest(conn, "nvim_exec_lua", [[return require"nabla".gen_drawing(...)]], { input })
-
-  local correct = true
-  if type(result) == "table" then
-    if #result == #output then
-      for i=1,#result do
-        if result[i] ~= output[i] then
-          correct = false
-          break
+    local lines = {}
+    local input = {}
+    local output = {}
+    local in_input = true
+    for line in io.lines(file) do
+        if in_input then
+            if string.match(line, "^%-%-%-") then
+                in_input = false
+            else
+                table.insert(input, line)
+            end
+        else
+            table.insert(output, line)
         end
-      end
-    else
-      correct = false
     end
-  else
-    result = "NO OUTPUT"
-    correct = false
-  end
 
-  local name = vim.fn.fnamemodify(file, ":t")
-  if correct then
-    print(name .. " OK!")
-  else
-    print(name .. " FAIL!")
-    print("Input: " .. vim.inspect(input))
-    print("Expected: " .. vim.inspect(output))
-    print("Result: " .. vim.inspect(result))
-    fail = true
-  end
+    local result = vim.fn.rpcrequest(conn, "nvim_exec_lua", [[return require"nabla".gen_drawing(...)]], { input })
 
+    local correct = true
+    if type(result) == "table" then
+        if #result == #output then
+            for i = 1, #result do
+                if result[i] ~= output[i] then
+                    correct = false
+                    break
+                end
+            end
+        else
+            correct = false
+        end
+    else
+        result = "NO OUTPUT"
+        correct = false
+    end
+
+    local name = vim.fn.fnamemodify(file, ":t")
+    if correct then
+        print(name .. " OK!")
+    else
+        print(name .. " FAIL!")
+        print("Input: " .. vim.inspect(input))
+        print("Expected: " .. vim.inspect(output))
+        print("Result: " .. vim.inspect(result))
+        fail = true
+    end
 end
 
 vim.fn.jobstop(conn)
 
 if not fail then
-  local f = io.open("result.txt", "w")
-  f:write("OK")
-  f:close()
-  print("OK")
+    local f = io.open("result.txt", "w")
+    f:write("OK")
+    f:close()
+    print("OK")
 end
-


### PR DESCRIPTION
This PR adds a `.stylua.toml` file to configure `.lua` file formatting. This way, future PRs will remain consistent in formatting and not have large diffs due to different contributor formatter settings.

I tried to pick sensible configuration options for the formatter configuration based on previous code style. For instance, one document had two space indents while the others had 4 spaces, so I opted for an indent width of 4 spaces.

This PR only adds formatting changes from stylua, and does not add any change to the code itself. I did, however, fix a small type in `utils.lua` where "nvim-treesitter" was spelt "nvim-tresitter" twice. That was the only non-formatting change.