### PR TITLE
reduce padding for virtual lines

### DIFF
--- a/lua/nabla.lua
+++ b/lua/nabla.lua
@@ -313,6 +313,12 @@ function enable_virt(opts)
 	end
 	mult_virt_ns[buf] = vim.api.nvim_create_namespace("")
 
+	local prev_row = -1
+	local prev_diff = 0
+
+	local next_prev_row
+	local next_prev_diff
+
 	local formula_nodes = utils.get_all_mathzones()
 	local formulas_loc = {}
 	for _, node in ipairs(formula_nodes) do
@@ -404,6 +410,11 @@ function enable_virt(opts)
   			end
 
   			for r, virt_line in ipairs(drawing_virt) do
+  				if srow ~= prev_row then
+  					prev_row = -1
+  					prev_diff = 0
+  				end
+
   				local relrow = r - g.my - 1
 
   				if srow == 0 then
@@ -427,7 +438,7 @@ function enable_virt(opts)
 
 
 
-  				local desired_col = p1 + 1
+  				local desired_col = p1
   				if relrow == 0 then
   					local chunks = {}
   					local margin_left = desired_col - p1
@@ -440,8 +451,10 @@ function enable_virt(opts)
   					vim.list_extend(chunks, virt_line)
 
   					for i=1,margin_right do
-  						table.insert(chunks, {" ", "NonText"})
+  						table.insert(chunks, {"", "NonText"})
   					end
+  					next_prev_row = srow
+  					next_prev_diff = margin_right + prev_diff
 
   					table.insert(inline_virt, { chunks, concealline, p1, p2 })
 
@@ -456,7 +469,11 @@ function enable_virt(opts)
   					end
 
   					local col = #vline
-  					for i=1,desired_col-col do
+  					local padding = desired_col - col
+  					if prev_row == srow then
+  						padding = padding - prev_diff
+  					end
+  					for i=1,padding do
   						table.insert(vline, { " ", "Normal" })
   					end
 
@@ -473,6 +490,11 @@ function enable_virt(opts)
   				end
 
   			end
+  			if next_prev_row then
+  				prev_diff = next_prev_diff
+  				prev_row = next_prev_row
+  			end
+
 
   			for r=1,erow-srow+1 do
   				local p1, p2


### PR DESCRIPTION
Hello, this PR reduces the padding of virtual lines so that lines with multiple formulas or text following formulas so they are more condensed.

Before:
![Before](https://github.com/jbyuki/nabla.nvim/assets/13501575/05b76901-d6bc-4a61-8cb6-0053b66df3b9)

After:
![After](https://github.com/jbyuki/nabla.nvim/assets/13501575/67be56be-9a1c-4059-abb7-b16cc9025a35)

I'm fairly inexperienced with lua, so the code may have a better possible implementation.