### PR TITLE
Fixes rendering in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Requirements
 * Neovim nightly
 * A colorscheme which supports treesitter [see here](https://github.com/rockerBOO/awesome-neovim#tree-sitter-supported-colorscheme)
 * Tree-sitter : [nvim-treesitter/nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
+  (Not a dependency, but recommended to install parsers).
 * Latex parser : Install with `TSInstall latex`.
 
 Install

--- a/lua/nabla.lua
+++ b/lua/nabla.lua
@@ -308,10 +308,9 @@ function enable_virt(opts)
 	local virt_lines_above = {}
 	local virt_lines_below = {}
 
-	if mult_virt_ns[buf] then
-	  vim.api.nvim_buf_clear_namespace(buf, mult_virt_ns[buf], 0, -1)
+	if mult_virt_ns[buf] == nil then
+      mult_virt_ns[buf] = vim.api.nvim_create_namespace("nabla.nvim")
 	end
-	mult_virt_ns[buf] = vim.api.nvim_create_namespace("")
 
 	local prev_row = -1
 	local prev_diff = 0
@@ -319,7 +318,7 @@ function enable_virt(opts)
 	local next_prev_row
 	local next_prev_diff
 
-	local formula_nodes = utils.get_all_mathzones()
+	local formula_nodes = utils.get_all_mathzones(opts)
 	local formulas_loc = {}
 	for _, node in ipairs(formula_nodes) do
 	  local srow, scol, erow, ecol = ts_utils.get_node_range(node)
@@ -566,6 +565,7 @@ function enable_virt(opts)
   	end
   end
 
+  local cleared_extmarks = {}
   -- @place_drawings_above_lines
 	for _, conceal in ipairs(inline_virt) do
 		local chunks, row, p1, p2 = unpack(conceal)
@@ -577,6 +577,10 @@ function enable_virt(opts)
 			end
 
 			if p1+j <= p2 then
+              if cleared_extmarks[row] == nil then
+                vim.api.nvim_buf_clear_namespace(buf, mult_virt_ns[buf], row, row + 1)
+                cleared_extmarks[row] = true
+              end
 				vim.api.nvim_buf_set_extmark(buf, mult_virt_ns[buf], row, p1+j-1, {
 					-- virt_text = {{ c, hl_group }},
 					end_row = row,
@@ -597,6 +601,10 @@ function enable_virt(opts)
 		end
 
 		if #virt_lines_reversed > 0 then
+            if cleared_extmarks[row] == nil then
+              vim.api.nvim_buf_clear_namespace(buf, mult_virt_ns[buf], row, row + 1)
+              cleared_extmarks[row] = true
+            end
 			vim.api.nvim_buf_set_extmark(buf, mult_virt_ns[buf], row, 0, {
 				virt_lines = virt_lines_reversed,
 				virt_lines_above = true,
@@ -606,6 +614,10 @@ function enable_virt(opts)
 
 	for row, virt_lines in pairs(virt_lines_below) do
 		if #virt_lines > 0 then
+            if cleared_extmarks[row] == nil then
+              vim.api.nvim_buf_clear_namespace(buf, mult_virt_ns[buf], row, row + 1)
+              cleared_extmarks[row] = true
+            end
 			vim.api.nvim_buf_set_extmark(buf, mult_virt_ns[buf], row, 0, {
 				virt_lines = virt_lines,
 			})

--- a/lua/nabla.lua
+++ b/lua/nabla.lua
@@ -309,7 +309,7 @@ function enable_virt(opts)
 	local virt_lines_below = {}
 
 	if mult_virt_ns[buf] == nil then
-      mult_virt_ns[buf] = vim.api.nvim_create_namespace("nabla.nvim")
+			mult_virt_ns[buf] = vim.api.nvim_create_namespace("nabla.nvim")
 	end
 
 	local prev_row = -1
@@ -322,7 +322,7 @@ function enable_virt(opts)
 	local formulas_loc = {}
 	for _, node in ipairs(formula_nodes) do
 	  local srow, scol, erow, ecol = ts_utils.get_node_range(node)
-		table.insert(formulas_loc, {srow, scol, erow, ecol})
+	  table.insert(formulas_loc, {srow, scol, erow, ecol})
 	end
 
   local conceal_padding = {}
@@ -363,39 +363,40 @@ function enable_virt(opts)
   			end
 
 
-        if not conceal_padding[srow] then
-          -- account for treesitter capture conceals
-          conceal_padding[srow] = vim.iter(vim.gsplit(vim.api.nvim_buf_get_lines(0, srow, srow + 1, false)[1], ''))
-              :fold({}, function(acc, _)
-                local conceal_cap = vim.iter(vim.treesitter.get_captures_at_pos(0, srow, #acc))
-                    :filter(function(v)
-                      return v.metadata.conceal
-                    end):next()
-                acc[#acc + 1] = (#acc == 0 and 0 or acc[#acc]) + 1 - (conceal_cap and vim.fn.strutf16len(conceal_cap.metadata.conceal) or 1)
-                return acc
-              end)
 
-          local marks = vim.iter(vim.api.nvim_buf_get_extmarks(0, -1, { srow, 0 }, { srow, -1 }, { details = true, }))
-          local last_stat = marks:filter(function(v) return v[4].virt_text and v[4].virt_text_pos == "inline" end)
-            :fold({0, 0}, function (stat, mark)
-                if stat[1] >= mark[3] then
-                  return { stat[1], stat[2] + vim.iter(mark[4].virt_text):fold(0, function(len, v)
-                    -- the third term accounts for replacement of a character with virt_text (1) vs addition of string (0)
-                    return len + vim.fn.strutf16len(v[1]) - 1
-                  end) }
-                end
-              for i = stat[1] + 1, mark[3] + 1 do
-                conceal_padding[srow][i] = conceal_padding[srow][i] - stat[2]
-              end
-            return {mark[3] + 1,
-              stat[2] + vim.iter(mark[4].virt_text):fold(0, function (len, v)
-                return len + vim.fn.strutf16len(v[1]) - 1
-              end)}
-            end)
-          for i = last_stat[1] + 1, #conceal_padding[srow] do
-            conceal_padding[srow][i] = conceal_padding[srow][i] - last_stat[2]
-          end
-        end
+  			if not conceal_padding[srow] then
+  			  -- account for treesitter capture conceals
+  			  conceal_padding[srow] = vim.iter(vim.gsplit(vim.api.nvim_buf_get_lines(0, srow, srow + 1, false)[1], ''))
+  			      :fold({}, function(acc, _)
+  			        local conceal_cap = vim.iter(vim.treesitter.get_captures_at_pos(0, srow, #acc))
+  			            :filter(function(v)
+  			              return v.metadata.conceal
+  			            end):next()
+  			        acc[#acc + 1] = (#acc == 0 and 0 or acc[#acc]) + 1 - (conceal_cap and vim.fn.strutf16len(conceal_cap.metadata.conceal) or 1)
+  			        return acc
+  			      end)
+
+  			  local marks = vim.iter(vim.api.nvim_buf_get_extmarks(0, -1, { srow, 0 }, { srow, -1 }, { details = true, }))
+  			  local last_stat = marks:filter(function(v) return v[4].virt_text and v[4].virt_text_pos == "inline" end)
+  			    :fold({0, 0}, function (stat, mark)
+  			        if stat[1] >= mark[3] then
+  			          return { stat[1], stat[2] + vim.iter(mark[4].virt_text):fold(0, function(len, v)
+  			            -- the third term accounts for replacement of a character with virt_text (1) vs addition of string (0)
+  			            return len + vim.fn.strutf16len(v[1]) - 1
+  			          end) }
+  			        end
+  			      for i = stat[1] + 1, mark[3] + 1 do
+  			        conceal_padding[srow][i] = conceal_padding[srow][i] - stat[2]
+  			      end
+  			    return {mark[3] + 1,
+  			      stat[2] + vim.iter(mark[4].virt_text):fold(0, function (len, v)
+  			        return len + vim.fn.strutf16len(v[1]) - 1
+  			      end)}
+  			    end)
+  			  for i = last_stat[1] + 1, #conceal_padding[srow] do
+  			    conceal_padding[srow][i] = conceal_padding[srow][i] - last_stat[2]
+  			  end
+  			end
 
   			local drawing_virt = {}
 
@@ -565,8 +566,8 @@ function enable_virt(opts)
   	end
   end
 
-  local cleared_extmarks = {}
   -- @place_drawings_above_lines
+	local cleared_extmarks = {}
 	for _, conceal in ipairs(inline_virt) do
 		local chunks, row, p1, p2 = unpack(conceal)
 
@@ -577,10 +578,11 @@ function enable_virt(opts)
 			end
 
 			if p1+j <= p2 then
-              if cleared_extmarks[row] == nil then
-                vim.api.nvim_buf_clear_namespace(buf, mult_virt_ns[buf], row, row + 1)
-                cleared_extmarks[row] = true
-              end
+				if cleared_extmarks[row] == nil then
+				  vim.api.nvim_buf_clear_namespace(buf, mult_virt_ns[buf], row, row + 1)
+				  cleared_extmarks[row] = true
+				end
+
 				vim.api.nvim_buf_set_extmark(buf, mult_virt_ns[buf], row, p1+j-1, {
 					-- virt_text = {{ c, hl_group }},
 					end_row = row,
@@ -601,10 +603,11 @@ function enable_virt(opts)
 		end
 
 		if #virt_lines_reversed > 0 then
-            if cleared_extmarks[row] == nil then
-              vim.api.nvim_buf_clear_namespace(buf, mult_virt_ns[buf], row, row + 1)
-              cleared_extmarks[row] = true
-            end
+			if cleared_extmarks[row] == nil then
+			  vim.api.nvim_buf_clear_namespace(buf, mult_virt_ns[buf], row, row + 1)
+			  cleared_extmarks[row] = true
+			end
+
 			vim.api.nvim_buf_set_extmark(buf, mult_virt_ns[buf], row, 0, {
 				virt_lines = virt_lines_reversed,
 				virt_lines_above = true,
@@ -614,10 +617,11 @@ function enable_virt(opts)
 
 	for row, virt_lines in pairs(virt_lines_below) do
 		if #virt_lines > 0 then
-            if cleared_extmarks[row] == nil then
-              vim.api.nvim_buf_clear_namespace(buf, mult_virt_ns[buf], row, row + 1)
-              cleared_extmarks[row] = true
-            end
+			if cleared_extmarks[row] == nil then
+			  vim.api.nvim_buf_clear_namespace(buf, mult_virt_ns[buf], row, row + 1)
+			  cleared_extmarks[row] = true
+			end
+
 			vim.api.nvim_buf_set_extmark(buf, mult_virt_ns[buf], row, 0, {
 				virt_lines = virt_lines,
 			})

--- a/lua/nabla.lua
+++ b/lua/nabla.lua
@@ -365,7 +365,6 @@ function enable_virt(opts)
 
 
         if not conceal_padding[srow] then
-          print(srow .. "->" .. vim.api.nvim_buf_get_lines(0, srow, srow + 1, false)[1])
           -- account for treesitter capture conceals
           conceal_padding[srow] = vim.iter(vim.gsplit(vim.api.nvim_buf_get_lines(0, srow, srow + 1, false)[1], ''))
               :fold({}, function(acc, _)
@@ -373,12 +372,11 @@ function enable_virt(opts)
                     :filter(function(v)
                       return v.metadata.conceal
                     end):next()
-                acc[#acc + 1] = (#acc == 0 and 0 or acc[#acc]) + 1 - (conceal_cap and #conceal_cap.metadata.conceal or 1)
+                acc[#acc + 1] = (#acc == 0 and 0 or acc[#acc]) + 1 - (conceal_cap and vim.fn.strutf16len(conceal_cap.metadata.conceal) or 1)
                 return acc
               end)
 
           local marks = vim.iter(vim.api.nvim_buf_get_extmarks(0, -1, { srow, 0 }, { srow, -1 }, { details = true, }))
-          print(vim.inspect(marks._table))
           local last_stat = marks:filter(function(v) return v[4].virt_text and v[4].virt_text_pos == "inline" end)
             :fold({0, 0}, function (stat, mark)
               for i = stat[1] + 1, mark[3] + 1 do
@@ -386,14 +384,12 @@ function enable_virt(opts)
               end
             return {mark[3] + 1,
               stat[2] + vim.iter(mark[4].virt_text):fold(0, function (len, v)
-                return len + #v[1]
+                return len + vim.fn.strutf16len(v[1]) - 1
               end)}
             end)
           for i = last_stat[1] + 1, #conceal_padding[srow] do
             conceal_padding[srow][i] = conceal_padding[srow][i] - last_stat[2]
           end
-
-          print(vim.inspect(conceal_padding[srow]))
         end
 
   			local drawing_virt = {}

--- a/lua/nabla.lua
+++ b/lua/nabla.lua
@@ -381,7 +381,7 @@ function enable_virt(opts)
                 if stat[1] >= mark[3] then
                   return { stat[1], stat[2] + vim.iter(mark[4].virt_text):fold(0, function(len, v)
                     -- the third term accounts for replacement of a character with virt_text (1) vs addition of string (0)
-                    return len + vim.fn.strutf16len(v[1]) - (mark[4].end_col and 1 or 0)
+                    return len + vim.fn.strutf16len(v[1]) - 1
                   end) }
                 end
               for i = stat[1] + 1, mark[3] + 1 do
@@ -389,7 +389,7 @@ function enable_virt(opts)
               end
             return {mark[3] + 1,
               stat[2] + vim.iter(mark[4].virt_text):fold(0, function (len, v)
-                return len + vim.fn.strutf16len(v[1]) - (mark[4].end_col and 1 or 0)
+                return len + vim.fn.strutf16len(v[1]) - 1
               end)}
             end)
           for i = last_stat[1] + 1, #conceal_padding[srow] do

--- a/lua/nabla.lua
+++ b/lua/nabla.lua
@@ -589,7 +589,7 @@ function enable_virt(opts)
 	-- vim.wo[win].wrap = false
 
 	if opts and opts.autogen then
-		autogen_autocmd[buf] = vim.api.nvim_create_autocmd({"InsertLeave"}, {
+		autogen_autocmd[buf] = vim.api.nvim_create_autocmd({"InsertLeave", "TextChanged"}, {
 			buffer = buf,
 			desc = "nabla.nvim: Regenerates virt_lines automatically when the user exists insert mode",
 			callback = function()

--- a/lua/nabla.lua
+++ b/lua/nabla.lua
@@ -379,12 +379,18 @@ function enable_virt(opts)
           local marks = vim.iter(vim.api.nvim_buf_get_extmarks(0, -1, { srow, 0 }, { srow, -1 }, { details = true, }))
           local last_stat = marks:filter(function(v) return v[4].virt_text and v[4].virt_text_pos == "inline" end)
             :fold({0, 0}, function (stat, mark)
+                if stat[1] >= mark[3] then
+                  return { stat[1], stat[2] + vim.iter(mark[4].virt_text):fold(0, function(len, v)
+                    -- the third term accounts for replacement of a character with virt_text (1) vs addition of string (0)
+                    return len + vim.fn.strutf16len(v[1]) - (mark[4].end_col and 1 or 0)
+                  end) }
+                end
               for i = stat[1] + 1, mark[3] + 1 do
                 conceal_padding[srow][i] = conceal_padding[srow][i] - stat[2]
               end
             return {mark[3] + 1,
               stat[2] + vim.iter(mark[4].virt_text):fold(0, function (len, v)
-                return len + vim.fn.strutf16len(v[1]) - 1
+                return len + vim.fn.strutf16len(v[1]) - (mark[4].end_col and 1 or 0)
               end)}
             end)
           for i = last_stat[1] + 1, #conceal_padding[srow] do

--- a/lua/nabla.lua
+++ b/lua/nabla.lua
@@ -365,6 +365,7 @@ function enable_virt(opts)
 
 
         if not conceal_padding[srow] then
+          print(srow .. "->" .. vim.api.nvim_buf_get_lines(0, srow, srow + 1, false)[1])
           -- account for treesitter capture conceals
           conceal_padding[srow] = vim.iter(vim.gsplit(vim.api.nvim_buf_get_lines(0, srow, srow + 1, false)[1], ''))
               :fold({}, function(acc, _)
@@ -375,6 +376,24 @@ function enable_virt(opts)
                 acc[#acc + 1] = (#acc == 0 and 0 or acc[#acc]) + 1 - (conceal_cap and #conceal_cap.metadata.conceal or 1)
                 return acc
               end)
+
+          local marks = vim.iter(vim.api.nvim_buf_get_extmarks(0, -1, { srow, 0 }, { srow, -1 }, { details = true, }))
+          print(vim.inspect(marks._table))
+          local last_stat = marks:filter(function(v) return v[4].virt_text and v[4].virt_text_pos == "inline" end)
+            :fold({0, 0}, function (stat, mark)
+              for i = stat[1] + 1, mark[3] + 1 do
+                conceal_padding[srow][i] = conceal_padding[srow][i] - stat[2]
+              end
+            return {mark[3] + 1,
+              stat[2] + vim.iter(mark[4].virt_text):fold(0, function (len, v)
+                return len + #v[1]
+              end)}
+            end)
+          for i = last_stat[1] + 1, #conceal_padding[srow] do
+            conceal_padding[srow][i] = conceal_padding[srow][i] - last_stat[2]
+          end
+
+          print(vim.inspect(conceal_padding[srow]))
         end
 
   			local drawing_virt = {}

--- a/lua/nabla.lua
+++ b/lua/nabla.lua
@@ -586,7 +586,7 @@ function enable_virt(opts)
 
 	local win = vim.api.nvim_get_current_win()
 	saved_wrapsettings[win] = vim.wo[win].wrap
-	vim.wo[win].wrap = false
+	-- vim.wo[win].wrap = false
 
 	if opts and opts.autogen then
 		autogen_autocmd[buf] = vim.api.nvim_create_autocmd({"InsertLeave"}, {

--- a/lua/nabla/utils.lua
+++ b/lua/nabla/utils.lua
@@ -111,6 +111,7 @@ utils.get_all_mathzones = function(opts)
   end
 
   local root_tree = parser:parse(opts.render_visible and { parse_span.top, parse_span.bottom } or true)[1]
+
   local root = root_tree and root_tree:root()
 
   if not root then

--- a/lua/nabla/utils.lua
+++ b/lua/nabla/utils.lua
@@ -94,20 +94,16 @@ utils.get_all_mathzones = function()
   if vim.bo.filetype == "markdown" then
     local injections = {}
 
-    parser:for_each_tree(function(parent_tree, parent_ltree)
-      local parent = parent_tree:root()
+    parser:for_each_tree(function(_, parent_ltree)
       for _, child in pairs(parent_ltree:children()) do
         for _, tree in pairs(child:trees()) do
           local r = tree:root()
-          local node = assert(parent:named_descendant_for_range(r:range()))
-          local id = node:id()
-          if not injections[id] then
+          local sr, sc, er, ec = ts.get_node_range(r)
+          local key = string.format("%s,%s,%s,%s", sr, sc, er, ec)
+          if not injections[key] then
             local lang = child:lang()
             if lang == "latex" then
-              injections[id] = {
-                lang = lang,
-                root = r,
-              }
+              injections[key] = true
               table.insert(out, r)
             end
           end

--- a/src/treesitter/detect_for_virt_lines.lua.t
+++ b/src/treesitter/detect_for_virt_lines.lua.t
@@ -1,6 +1,6 @@
 ##../nabla
 @utils_functions+=
-utils.get_all_mathzones = function()
+utils.get_all_mathzones = function(opts)
   @get_tree_root_ts
   @go_downwards_and_search_for_math_nodes
   return out
@@ -11,13 +11,13 @@ vim.api.nvim_echo({{"Latex parser not found. Please install with nvim-treesitter
 
 @get_tree_root_ts+=
 local buf = vim.api.nvim_get_current_buf()
-local ok, parser = pcall(ts.get_parser, buf, "latex")
+local ok, parser = pcall(ts.get_parser, buf, vim.bo.filetype~="markdown" and "latex" or "markdown")
 if not ok or not parser then
   @warn_if_latex_is_not_installed
   return {}
 end
 
-local root_tree = parser:parse()[1]
+@parse_latex_with_markdown_fix
 local root = root_tree and root_tree:root()
 
 if not root then
@@ -52,14 +52,14 @@ end
 
 @go_downwards_and_search_for_math_nodes+=
 local out = {}
-utils.get_mathzones_in_node(root, out)
+@get_mathzones_with_markdown_fix
 
 @detect_all_formulas+=
-local formula_nodes = utils.get_all_mathzones()
+local formula_nodes = utils.get_all_mathzones(opts)
 local formulas_loc = {}
 for _, node in ipairs(formula_nodes) do
   local srow, scol, erow, ecol = ts_utils.get_node_range(node)
-	table.insert(formulas_loc, {srow, scol, erow, ecol})
+  table.insert(formulas_loc, {srow, scol, erow, ecol})
 end
 
 @detect_formulas_in_line+=

--- a/src/treesitter/detect_mathzone.lua.t
+++ b/src/treesitter/detect_mathzone.lua.t
@@ -17,6 +17,8 @@ local MATH_NODES = {
     inline_formula = true,
 }
 
+RENDER_CACHE = {}
+
 utils.in_mathzone = function()
     local function get_node_at_cursor()
         local cursor = vim.api.nvim_win_get_cursor(0)

--- a/src/viewmode/autogen.lua.t
+++ b/src/viewmode/autogen.lua.t
@@ -4,7 +4,7 @@ local autogen_autocmd = {}
 local autogen_flag = false
 
 @enable_autogen+=
-autogen_autocmd[buf] = vim.api.nvim_create_autocmd({"InsertLeave"}, {
+autogen_autocmd[buf] = vim.api.nvim_create_autocmd({"InsertLeave", "TextChanged"}, {
 	buffer = buf,
 	desc = "nabla.nvim: Regenerates virt_lines automatically when the user exists insert mode",
 	callback = function()

--- a/src/viewmode/fix_markdown.lua.t
+++ b/src/viewmode/fix_markdown.lua.t
@@ -1,0 +1,93 @@
+##../nabla
+@fix_rendering_markdown+=
+if not conceal_padding[srow] then
+  -- account for treesitter capture conceals
+  conceal_padding[srow] = vim.iter(vim.gsplit(vim.api.nvim_buf_get_lines(0, srow, srow + 1, false)[1], ''))
+      :fold({}, function(acc, _)
+        local conceal_cap = vim.iter(vim.treesitter.get_captures_at_pos(0, srow, #acc))
+            :filter(function(v)
+              return v.metadata.conceal
+            end):next()
+        acc[#acc + 1] = (#acc == 0 and 0 or acc[#acc]) + 1 - (conceal_cap and vim.fn.strutf16len(conceal_cap.metadata.conceal) or 1)
+        return acc
+      end)
+
+  local marks = vim.iter(vim.api.nvim_buf_get_extmarks(0, -1, { srow, 0 }, { srow, -1 }, { details = true, }))
+  local last_stat = marks:filter(function(v) return v[4].virt_text and v[4].virt_text_pos == "inline" end)
+    :fold({0, 0}, function (stat, mark)
+        if stat[1] >= mark[3] then
+          return { stat[1], stat[2] + vim.iter(mark[4].virt_text):fold(0, function(len, v)
+            -- the third term accounts for replacement of a character with virt_text (1) vs addition of string (0)
+            return len + vim.fn.strutf16len(v[1]) - 1
+          end) }
+        end
+      for i = stat[1] + 1, mark[3] + 1 do
+        conceal_padding[srow][i] = conceal_padding[srow][i] - stat[2]
+      end
+    return {mark[3] + 1,
+      stat[2] + vim.iter(mark[4].virt_text):fold(0, function (len, v)
+        return len + vim.fn.strutf16len(v[1]) - 1
+      end)}
+    end)
+  for i = last_stat[1] + 1, #conceal_padding[srow] do
+    conceal_padding[srow][i] = conceal_padding[srow][i] - last_stat[2]
+  end
+end
+
+@cleared_extmarks+=
+if cleared_extmarks[row] == nil then
+  vim.api.nvim_buf_clear_namespace(buf, mult_virt_ns[buf], row, row + 1)
+  cleared_extmarks[row] = true
+end
+
+@parse_latex_with_markdown_fix+=
+local top, bottom = vim.fn.line('w0') - 1, vim.fn.line('w$')
+local parse_span
+local cache = RENDER_CACHE[buf]
+if not cache then
+  RENDER_CACHE[buf] = { top = top, bottom = bottom, changedtick = vim.api.nvim_buf_get_changedtick(buf) }
+  parse_span = { top = top, bottom = bottom }
+else
+  if cache.changedtick ~= vim.api.nvim_buf_get_changedtick(buf) then
+    local line = vim.fn.line('.') - 1
+    parse_span = vim.fn.mode() == 'i' and { top = line, bottom = line + 1 } or { top = top, bottom = bottom }
+    cache.changedtick = vim.api.nvim_buf_get_changedtick(buf)
+  else
+    parse_span = {
+      top = top < cache.top and top or (top >= cache.bottom and top or cache.bottom),
+      bottom = bottom > cache.bottom and bottom or (bottom >= cache.top and cache.top or bottom),
+    }
+  end
+  cache.top = math.min(cache.top, parse_span.top)
+  cache.bottom = math.max(cache.bottom, parse_span.bottom)
+end
+
+if not parse_span or parse_span.top >= parse_span.bottom then
+  return {}
+end
+
+local root_tree = parser:parse(opts.render_visible and { parse_span.top, parse_span.bottom } or true)[1]
+
+@get_mathzones_with_markdown_fix+=
+if vim.bo.filetype == "markdown" then
+  local injections = {}
+
+  parser:for_each_tree(function(_, parent_ltree)
+    for _, child in pairs(parent_ltree:children()) do
+      for _, tree in pairs(child:trees()) do
+        local r = tree:root()
+        local sr, sc, er, ec = ts.get_node_range(r)
+        local key = string.format("%s,%s,%s,%s", sr, sc, er, ec)
+        if not injections[key] then
+          local lang = child:lang()
+          if lang == "latex" then
+            injections[key] = true
+            table.insert(out, r)
+          end
+        end
+      end
+    end
+  end)
+else
+  utils.get_mathzones_in_node(root, out)
+end


### PR DESCRIPTION
Hi there,

Not sure if this plugin is any longer active.

Nonetheless, I tried to fix the rendering in markdown, especially for [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim). Previously, it was treating any document as a latex file to identify the `mathzones`, which is erroneous---consider the $ of shell variables. I tried to fix this and also consider the fancy extmarks and virtual text into account.

I use with render-markdown using this config:
```lua
on = {
     render = function()
       require('nabla').enable_virt({ autogen = false, render_visible = true })
     end,
},
```

Thanks!